### PR TITLE
Add gasless tc

### DIFF
--- a/klayslave/account/account.go
+++ b/klayslave/account/account.go
@@ -365,6 +365,38 @@ func (self *Account) TransferSignedTxWithGuaranteeRetry(c *client.Client, to *Ac
 	return lastTx
 }
 
+func (self *Account) TransferTestTokenSignedTxWithGuaranteeRetry(c *client.Client, to *Account, value *big.Int, testTokenAddr common.Address) *types.Transaction {
+	var (
+		err    error
+		lastTx *types.Transaction
+	)
+
+	for {
+		testToken := NewKaiaAccountWithAddr(0, testTokenAddr)
+		data := TestContractInfos[ContractErc20].GenData(to.GetAddress(), value)
+		lastTx, _, err = self.TransferNewSmartContractExecutionTx(c, testToken, common.Big0, data)
+		// TODO-kaia-load-tester: return error if the error isn't able to handle
+		if err == nil {
+			break // Succeed, let's break the loop
+		}
+		log.Printf("Failed to execute: err=%s", err.Error())
+		time.Sleep(1 * time.Second) // Mostly, the err is `txpool is full`, retry after a while.
+		//numChargedAcc, lastFailedNum = estimateRemainingTime(accGrp, numChargedAcc, lastFailedNum)
+	}
+
+	ctx, cancelFn := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancelFn()
+
+	receipt, err := bind.WaitMined(ctx, c, lastTx)
+	cancelFn()
+	if err != nil || (receipt != nil && receipt.Status == 0) {
+		// shouldn't happen. must check if contract is correct.
+		fmt.Println(receipt, lastTx)
+		log.Fatalf("tx mined but failed, err=%s, txHash=%s", err, lastTx.Hash().String())
+	}
+	return lastTx
+}
+
 func (self *Account) TransferSignedTxWithoutLock(c *client.Client, to *Account, value *big.Int) (common.Hash, *big.Int, error) {
 	tx, gasPrice, err := self.TransferSignedTxReturnTx(false, c, to, value)
 	return tx.Hash(), gasPrice, err
@@ -1807,6 +1839,87 @@ func (self *Account) TransferNewLegacyTxWithEth(c *client.Client, endpoint strin
 	return common.HexToHash(strResult), gasPrice, nil
 }
 
+// This function is responsible for sending both Gasless Approve Transactions and Gasless Swap Transactions.
+func (self *Account) TransferNewGaslessTx(c *client.Client, endpoint string, testToken, gsr *Account) (common.Hash, common.Hash, *big.Int, error) {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
+	nonce := self.GetNonce(c)
+
+	approveInput, err := MakeApproveFunctionCall(gsr.GetAddress())
+	if err != nil {
+		fmt.Printf("Failed to creat arguments to send approve Tx: %v\n", err.Error())
+		return common.Hash{0}, common.Hash{0}, gasPrice, err
+	}
+
+	ctx := context.Background()
+	suggestedGasPrice, err := c.SuggestGasPrice(ctx)
+	if err != nil {
+		fmt.Printf("Failed to fetch suggest gas price: %v\n", err.Error())
+		return common.Hash{0}, common.Hash{0}, gasPrice, err
+	}
+	swapInput, err := MakeSwapFunctionCall(testToken.GetAddress(), suggestedGasPrice)
+	if err != nil {
+		fmt.Printf("Failed to creat arguments to send swap Tx: %v\n", err.Error())
+		return common.Hash{0}, common.Hash{0}, gasPrice, err
+	}
+
+	approveTx := types.NewTransaction(
+		nonce,
+		testToken.address,
+		common.Big0,
+		100000,
+		suggestedGasPrice,
+		approveInput)
+	signApproveTx, err := types.SignTx(approveTx, types.NewEIP155Signer(chainID), self.privateKey[0])
+	if err != nil {
+		log.Fatalf("Failed to encode approve tx: %v", err)
+	}
+
+	swapTx := types.NewTransaction(
+		nonce+1,
+		gsr.address,
+		common.Big0,
+		500000,
+		suggestedGasPrice,
+		swapInput)
+	signSwapTx, err := types.SignTx(swapTx, types.NewEIP155Signer(chainID), self.privateKey[0])
+	if err != nil {
+		log.Fatalf("Failed to encode swap tx: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+
+	_, err = c.SendRawTransaction(ctx, signApproveTx)
+	if err != nil {
+		if err.Error() == blockchain.ErrNonceTooLow.Error() || err.Error() == blockchain.ErrReplaceUnderpriced.Error() {
+			fmt.Printf("Account(%v) nonce(%v) : Failed to sendTransaction: %v\n", self.GetAddress().String(), nonce, err)
+			fmt.Printf("Account(%v) nonce is added to %v\n", self.GetAddress().String(), nonce+1)
+			self.nonce++
+		} else {
+			fmt.Printf("Account(%v) nonce(%v) : Failed to sendTransaction: %v\n", self.GetAddress().String(), nonce, err)
+		}
+		return approveTx.Hash(), swapTx.Hash(), suggestedGasPrice, err
+	}
+
+	_, err = c.SendRawTransaction(ctx, signSwapTx)
+	if err != nil {
+		if err.Error() == blockchain.ErrNonceTooLow.Error() || err.Error() == blockchain.ErrReplaceUnderpriced.Error() {
+			fmt.Printf("Account(%v) nonce(%v) : Failed to sendTransaction: %v\n", self.GetAddress().String(), nonce, err)
+			fmt.Printf("Account(%v) nonce is added to %v\n", self.GetAddress().String(), nonce+1)
+			self.nonce++
+		} else {
+			fmt.Printf("Account(%v) nonce(%v) : Failed to sendTransaction: %v\n", self.GetAddress().String(), nonce, err)
+		}
+		return approveTx.Hash(), swapTx.Hash(), suggestedGasPrice, err
+	}
+
+	self.nonce += 2
+
+	return approveTx.Hash(), swapTx.Hash(), suggestedGasPrice, nil
+}
+
 func (self *Account) TransferNewEthAccessListTxWithEth(c *client.Client, endpoint string, to *Account, value *big.Int, input string, exePath string) (common.Hash, *big.Int, error) {
 	self.mutex.Lock()
 	defer self.mutex.Unlock()
@@ -2011,4 +2124,46 @@ func (a *Account) CheckBalance(expectedBalance *big.Int, cli *client.Client) err
 	}
 
 	return nil
+}
+
+func MakeApproveFunctionCall(spender common.Address) ([]byte, error) {
+	abiStr := `[{"inputs":[{"name":"_spender","type":"address"},{"name":"_value","type":"uint256"}],"name":"approve","outputs":[{"name":"","type":"bool"}],"payable":false,"stateMutability":"nonpayable","type":"function"}]`
+	abii, err := abi.JSON(strings.NewReader(abiStr))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ABI: %v", err)
+	}
+
+	data, err := abii.Pack("approve", spender, abi.MaxUint256) // Approve maximum amount
+	if err != nil {
+		return nil, fmt.Errorf("failed to pack approve data: %v", err)
+	}
+
+	return data, nil
+}
+
+func MakeSwapFunctionCall(testTokenAddress common.Address, suggestedGasPrice *big.Int) ([]byte, error) {
+	abiStr := `[{"inputs":[{"internalType":"address","name":"token","type":"address"},{"internalType":"uint256","name":"amountIn","type":"uint256"},{"internalType":"uint256","name":"minAmountOut","type":"uint256"},{"internalType":"uint256","name":"amountRepay","type":"uint256"},{"internalType":"uint256","name":"deadline","type":"uint256"}],"name":"swapForGas","outputs":[],"stateMutability":"nonpayable","type":"function"}]`
+	abii, err := abi.JSON(strings.NewReader(abiStr))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ABI: %v", err)
+	}
+
+	var (
+		R1          = new(big.Int).Mul(big.NewInt(21000), suggestedGasPrice)
+		R2          = new(big.Int).Mul(big.NewInt(100000), suggestedGasPrice)
+		R3          = new(big.Int).Mul(big.NewInt(500000), suggestedGasPrice)
+		amountRepay = new(big.Int).Add(R1, new(big.Int).Add(R2, R3)) // Amount to repay
+	)
+
+	// Set parameters for swap
+	amountIn := new(big.Int).Mul(amountRepay, big.NewInt(10))    // There must be enough input to output amountRepay.
+	minAmountOut := amountRepay                                  // Since nothing will be done after the swap, the amountRepay is sufficient.
+	deadline := big.NewInt(time.Now().Add(1 * time.Hour).Unix()) // Deadline 1 hour from now
+
+	data, err := abii.Pack("swapForGas", testTokenAddress, amountIn, minAmountOut, amountRepay, deadline)
+	if err != nil {
+		return nil, fmt.Errorf("failed to pack swap data: %v", err)
+	}
+
+	return data, nil
 }

--- a/klayslave/account/account.go
+++ b/klayslave/account/account.go
@@ -353,7 +353,7 @@ func (self *Account) TransferSignedTxWithGuaranteeRetry(c *client.Client, to *Ac
 		//numChargedAcc, lastFailedNum = estimateRemainingTime(accGrp, numChargedAcc, lastFailedNum)
 	}
 
-	ctx, cancelFn := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancelFn := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancelFn()
 
 	receipt, err := bind.WaitMined(ctx, c, lastTx)
@@ -384,7 +384,7 @@ func (self *Account) TransferTestTokenSignedTxWithGuaranteeRetry(c *client.Clien
 		//numChargedAcc, lastFailedNum = estimateRemainingTime(accGrp, numChargedAcc, lastFailedNum)
 	}
 
-	ctx, cancelFn := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancelFn := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancelFn()
 
 	receipt, err := bind.WaitMined(ctx, c, lastTx)

--- a/klayslave/config/config.go
+++ b/klayslave/config/config.go
@@ -121,7 +121,7 @@ func (cfg *Config) setConfigsFromFlag(ctx *cli.Context) {
 	if len(cfg.tcNameList) == 0 {
 		log.Fatal("No valid Tc is set. Please set valid TcList. \n Input tcList was '" + tcNames + "'")
 	}
-	if cfg.InTheTcList("gaslessTransactionTC") && (cfg.testTokenAddress == "" || cfg.gsrAddress == "") {
+	if (cfg.InTheTcList("gaslessTransactionTC") || cfg.InTheTcList("gaslessRevertTransactionTC")) && (cfg.testTokenAddress == "" || cfg.gsrAddress == "") {
 		log.Fatal("When executing gaslessTransactionTC, the flags: testTokenAddr and gsrAddr are required. e.g) -testTokenAddr $Address -gsrAddr $Address")
 	}
 

--- a/klayslave/config/config.go
+++ b/klayslave/config/config.go
@@ -29,6 +29,9 @@ type Config struct {
 	tcNameList           []string
 	tcWeights            []int
 
+	testTokenAddress string
+	gsrAddress       string
+
 	chargeKLAYAmount  int
 	chargeParallelNum int
 
@@ -79,6 +82,8 @@ func (cfg *Config) setConfigsFromFlag(ctx *cli.Context) {
 	cfg.chargeKLAYAmount = ctx.Int("charge")
 	cfg.chargeParallelNum = ctx.Int("chargeParallel")
 	cfg.richWalletPrivateKey = ctx.String("key")
+	cfg.testTokenAddress = ctx.String("testTokenAddr")
+	cfg.gsrAddress = ctx.String("gsrAddr")
 
 	// Do not allow null richWalletPrivateKey
 	if cfg.richWalletPrivateKey == "" {
@@ -116,6 +121,9 @@ func (cfg *Config) setConfigsFromFlag(ctx *cli.Context) {
 	if len(cfg.tcNameList) == 0 {
 		log.Fatal("No valid Tc is set. Please set valid TcList. \n Input tcList was '" + tcNames + "'")
 	}
+	if cfg.InTheTcList("gaslessTransactionTC") && (cfg.testTokenAddress == "" || cfg.gsrAddress == "") {
+		log.Fatal("When executing gaslessTransactionTC, the flags: testTokenAddr and gsrAddr are required. e.g) -testTokenAddr $Address -gsrAddr $Address")
+	}
 
 	fmt.Println("Arguments are set like the following:")
 	fmt.Printf("- Target EndPoint = %v\n", cfg.gEndpoint)
@@ -126,6 +134,10 @@ func (cfg *Config) setConfigsFromFlag(ctx *cli.Context) {
 	fmt.Printf("- charging KLAY Amount = %v\n", cfg.chargeKLAYAmount)
 	fmt.Printf("- tc = %v\n", cfg.tcNameList)
 	fmt.Printf("- weights = %v\n", cfg.tcWeights)
+	if cfg.InTheTcList("gaslessTransactionTC") {
+		fmt.Printf("- testTokenAddr = %v\n", cfg.testTokenAddress)
+		fmt.Printf("- gsrAddr = %v\n", cfg.gsrAddress)
+	}
 }
 
 func (cfg *Config) setConfigsFromNode() {
@@ -197,6 +209,8 @@ func (cfg *Config) GetNUserForNewAccounts() int     { return cfg.nUserForNewAcco
 func (cfg *Config) GetGEndpoint() string            { return cfg.gEndpoint }
 func (cfg *Config) GetActiveUserPercent() int       { return cfg.activeUserPercent }
 func (cfg *Config) GetTcStrList() []string          { return cfg.tcNameList }
+func (cfg *Config) GetTestTokenAddress() string     { return cfg.testTokenAddress }
+func (cfg *Config) GetGsrAddress() string           { return cfg.gsrAddress }
 func (cfg *Config) GetRichWalletPrivateKey() string { return cfg.richWalletPrivateKey }
 func (cfg *Config) GetGCli() *klay.Client           { return cfg.gCli }
 func (cfg *Config) InTheTcList(tcName string) bool {
@@ -226,6 +240,8 @@ var Flags = []cli.Flag{
 	cli.StringFlag{Name: "key", Usage: "private key of rich account for kaia charging of test accounts"},
 	cli.StringFlag{Name: "tc", Value: "", Usage: "tasks which user want to run, multiple tasks are separated by comma."},
 	cli.StringFlag{Name: "weights", Value: "", Usage: "weights which user want to run, multiple weights are separated by comma."},
+	cli.StringFlag{Name: "testTokenAddr", Value: "", Usage: "Address of TestToken Contract"},
+	cli.StringFlag{Name: "gsrAddr", Value: "", Usage: "Address of Gasless Swap Router"},
 }
 
 var BoomerFlags = []cli.Flag{

--- a/klayslave/main.go
+++ b/klayslave/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kaiachain/kaia-load-tester/testcase/ethereumTxAccessListTC"
 	"github.com/kaiachain/kaia-load-tester/testcase/ethereumTxDynamicFeeTC"
 	"github.com/kaiachain/kaia-load-tester/testcase/ethereumTxLegacyTC"
+	"github.com/kaiachain/kaia-load-tester/testcase/gaslessRevertTransactionTC"
 	"github.com/kaiachain/kaia-load-tester/testcase/gaslessTransactionTC"
 	"github.com/kaiachain/kaia-load-tester/testcase/newEthereumAccessListTC"
 	"github.com/kaiachain/kaia-load-tester/testcase/newEthereumDynamicFeeTC"
@@ -100,6 +101,8 @@ func setSmartContractAddressPerPackage(cfg *config.Config, a *account.AccGroup) 
 
 	gaslessTransactionTC.TestTokenAccount = account.NewKaiaAccountWithAddr(0, common.HexToAddress(cfg.GetTestTokenAddress()))
 	gaslessTransactionTC.GsrAccount = account.NewKaiaAccountWithAddr(0, common.HexToAddress(cfg.GetGsrAddress()))
+	gaslessRevertTransactionTC.TestTokenAccount = account.NewKaiaAccountWithAddr(0, common.HexToAddress(cfg.GetTestTokenAddress()))
+	gaslessRevertTransactionTC.GsrAccount = account.NewKaiaAccountWithAddr(0, common.HexToAddress(cfg.GetGsrAddress()))
 }
 
 // createTestAccGroupsAndPrepareContracts do every init steps before task.Init

--- a/klayslave/main.go
+++ b/klayslave/main.go
@@ -84,7 +84,7 @@ func RunAction(ctx *cli.Context) {
 }
 
 // TODO-kaia-load-tester: remove global variables in the tc packages
-func setSmartContractAddressPerPackage(cfg *config.Config, a *account.AccGroup) {
+func setSmartContractAddressPerPackage(a *account.AccGroup) {
 	erc20TransferTC.SmartContractAccount = a.GetTestContractByName(account.ContractErc20)
 	erc721TransferTC.SmartContractAccount = a.GetTestContractByName(account.ContractErc721)
 	storageTrieWriteTC.SmartContractAccount = a.GetTestContractByName(account.ContractStorageTrie)
@@ -147,7 +147,7 @@ func createTestAccGroupsAndPrepareContracts(cfg *config.Config, accGrp *account.
 	accGrp.DeployTestContracts(cfg.GetTcStrList(), globalReservoirAccount, localReservoirAccount, cfg.GetGCli(), cfg.GetChargeValue(), skipDeploys)
 
 	// Set SmartContractAddress value in each packages if needed
-	setSmartContractAddressPerPackage(cfg, accGrp)
+	setSmartContractAddressPerPackage(accGrp)
 	return localReservoirAccount
 }
 

--- a/testcase/gaslessRevertTransactionTC/gaslessRevertTransactionTC.go
+++ b/testcase/gaslessRevertTransactionTC/gaslessRevertTransactionTC.go
@@ -1,0 +1,68 @@
+package gaslessRevertTransactionTC
+
+import (
+	"log"
+	"math/big"
+	"math/rand"
+
+	"github.com/kaiachain/kaia-load-tester/klayslave/account"
+	"github.com/kaiachain/kaia-load-tester/klayslave/clipool"
+	"github.com/kaiachain/kaia/client"
+	"github.com/myzhan/boomer"
+)
+
+const Name = "gaslessRevertTransactionTC"
+
+var (
+	endPoint string
+	nAcc     int
+	accGrp   []*account.Account
+	cliPool  clipool.ClientPool
+	gasPrice *big.Int
+
+	TestTokenAccount *account.Account
+	GsrAccount       *account.Account
+)
+
+func Init(accs []*account.Account, endpoint string, gp *big.Int) {
+	gasPrice = gp
+
+	endPoint = endpoint
+
+	cliCreate := func() interface{} {
+		c, err := client.Dial(endPoint)
+		if err != nil {
+			log.Fatalf("Failed to connect RPC: %v", err)
+		}
+		return c
+	}
+
+	cliPool.Init(20, 300, cliCreate)
+
+	for _, acc := range accs {
+		accGrp = append(accGrp, acc)
+	}
+
+	nAcc = len(accGrp)
+}
+
+func Run() {
+	cli := cliPool.Alloc().(*client.Client)
+
+	from := accGrp[rand.Int()%nAcc]
+	testRecordName := "TransferNewGaslessRevertTx" + " to " + endPoint
+
+	start := boomer.Now()
+
+	_, _, _, err := from.TransferNewGaslessTx(cli, endPoint, TestTokenAccount, GsrAccount)
+
+	elapsed := boomer.Now() - start
+
+	cliPool.Free(cli)
+
+	if err != nil {
+		boomer.RecordFailure("http", testRecordName, elapsed, err.Error())
+	} else {
+		boomer.RecordSuccess("http", testRecordName, elapsed, int64(10))
+	}
+}

--- a/testcase/gaslessTransactionTC/gaslessTransactionTC.go
+++ b/testcase/gaslessTransactionTC/gaslessTransactionTC.go
@@ -1,0 +1,65 @@
+package gaslessTransactionTC
+
+import (
+	"log"
+	"math/big"
+	"math/rand"
+
+	"github.com/kaiachain/kaia-load-tester/klayslave/account"
+	"github.com/kaiachain/kaia-load-tester/klayslave/clipool"
+	"github.com/kaiachain/kaia/client"
+	"github.com/myzhan/boomer"
+)
+
+const Name = "gaslessTransactionTC"
+
+var (
+	endPoint string
+	nAcc     int
+	accGrp   []*account.Account
+	cliPool  clipool.ClientPool
+
+	TestTokenAccount *account.Account
+	GsrAccount       *account.Account
+)
+
+func Init(accs []*account.Account, endpoint string, gp *big.Int) {
+	endPoint = endpoint
+
+	cliCreate := func() interface{} {
+		c, err := client.Dial(endPoint)
+		if err != nil {
+			log.Fatalf("Failed to connect RPC: %v", err)
+		}
+		return c
+	}
+
+	cliPool.Init(20, 300, cliCreate)
+
+	for _, acc := range accs {
+		accGrp = append(accGrp, acc)
+	}
+
+	nAcc = len(accGrp)
+}
+
+func Run() {
+	cli := cliPool.Alloc().(*client.Client)
+
+	from := accGrp[rand.Int()%nAcc]
+	testRecordName := "TransferNewGaslessTx" + " to " + endPoint
+
+	start := boomer.Now()
+
+	_, _, _, err := from.TransferNewGaslessTx(cli, endPoint, TestTokenAccount, GsrAccount)
+
+	elapsed := boomer.Now() - start
+
+	cliPool.Free(cli)
+
+	if err != nil {
+		boomer.RecordFailure("http", testRecordName, elapsed, err.Error())
+	} else {
+		boomer.RecordSuccess("http", testRecordName, elapsed, int64(10))
+	}
+}

--- a/testcase/tclist.go
+++ b/testcase/tclist.go
@@ -434,13 +434,13 @@ var TcList = map[string]*ExtendedTask{
 		Init:   readApiCallContractTC.Init,
 	},
 	"gaslessTransactionTC": {
-		Name:   "gaslessTransactionTC",
+		Name:   gaslessTransactionTC.Name,
 		Weight: 10,
 		Fn:     gaslessTransactionTC.Run,
 		Init:   gaslessTransactionTC.Init,
 	},
 	"gaslessRevertTransactionTC": {
-		Name:   "gaslessRevertTransactionTC",
+		Name:   gaslessRevertTransactionTC.Name,
 		Weight: 10,
 		Fn:     gaslessRevertTransactionTC.Run,
 		Init:   gaslessRevertTransactionTC.Init,

--- a/testcase/tclist.go
+++ b/testcase/tclist.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kaiachain/kaia-load-tester/testcase/ethereumTxAccessListTC"
 	"github.com/kaiachain/kaia-load-tester/testcase/ethereumTxDynamicFeeTC"
 	"github.com/kaiachain/kaia-load-tester/testcase/ethereumTxLegacyTC"
+	"github.com/kaiachain/kaia-load-tester/testcase/gaslessRevertTransactionTC"
 	"github.com/kaiachain/kaia-load-tester/testcase/gaslessTransactionTC"
 	"github.com/kaiachain/kaia-load-tester/testcase/internalTxTC"
 	"github.com/kaiachain/kaia-load-tester/testcase/largeMemoTC"
@@ -441,8 +442,8 @@ var TcList = map[string]*ExtendedTask{
 	"gaslessRevertTransactionTC": {
 		Name:   "gaslessRevertTransactionTC",
 		Weight: 10,
-		Fn:     gaslessTransactionTC.Run,
-		Init:   gaslessTransactionTC.Init,
+		Fn:     gaslessRevertTransactionTC.Run,
+		Init:   gaslessRevertTransactionTC.Init,
 	},
 	"ethereumTxLegacyTC": {
 		Name:   "ethereumTxLegacyTC",

--- a/testcase/tclist.go
+++ b/testcase/tclist.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kaiachain/kaia-load-tester/testcase/ethereumTxAccessListTC"
 	"github.com/kaiachain/kaia-load-tester/testcase/ethereumTxDynamicFeeTC"
 	"github.com/kaiachain/kaia-load-tester/testcase/ethereumTxLegacyTC"
+	"github.com/kaiachain/kaia-load-tester/testcase/gaslessTransactionTC"
 	"github.com/kaiachain/kaia-load-tester/testcase/internalTxTC"
 	"github.com/kaiachain/kaia-load-tester/testcase/largeMemoTC"
 	"github.com/kaiachain/kaia-load-tester/testcase/newAccountCreationTC"
@@ -430,6 +431,18 @@ var TcList = map[string]*ExtendedTask{
 		Weight: 10,
 		Fn:     readApiCallContractTC.EstimateGas,
 		Init:   readApiCallContractTC.Init,
+	},
+	"gaslessTransactionTC": {
+		Name:   "gaslessTransactionTC",
+		Weight: 10,
+		Fn:     gaslessTransactionTC.Run,
+		Init:   gaslessTransactionTC.Init,
+	},
+	"gaslessRevertTransactionTC": {
+		Name:   "gaslessRevertTransactionTC",
+		Weight: 10,
+		Fn:     gaslessTransactionTC.Run,
+		Init:   gaslessTransactionTC.Init,
 	},
 	"ethereumTxLegacyTC": {
 		Name:   "ethereumTxLegacyTC",


### PR DESCRIPTION
## Description

This PR adds a test case for continuing to send gasless transactions and a test case for continuing to send gasless transactions (expected revert).

## Changes

- Add gaslessTransactionTC
- Add gaslessRevertTransactionTC
  - The swap transaction is reverted by not distributing the test token during initialization.
  - https://github.com/kaiachain/kaia-load-tester/pull/8/files#diff-3915deefd3e629f7e853cf8eafbc07c63fb4e6169b5022203dbd1cfc2a0f9c4aR138
- Efficiency of asset distribution in initialize