### PR TITLE
gasless: Add approve only tc

### DIFF
--- a/klayslave/account/contract.go
+++ b/klayslave/account/contract.go
@@ -84,7 +84,7 @@ var TestContractInfos = []struct {
 		},
 	},
 	{
-		[]string{"gaslessTransactionTC", "gaslessRevertTransactionTC"},
+		[]string{"gaslessTransactionTC", "gaslessRevertTransactionTC", "gaslessOnlyApproveTC"},
 		[]byte{},
 		&Account{},
 		"ERC20 Test Token for gasless swap",
@@ -103,7 +103,7 @@ var TestContractInfos = []struct {
 		},
 	},
 	{
-		[]string{"gaslessTransactionTC", "gaslessRevertTransactionTC"},
+		[]string{"gaslessTransactionTC", "gaslessRevertTransactionTC", "gaslessOnlyApproveTC"},
 		[]byte{},
 		&Account{},
 		"Gasless Swap Router for testing GA",

--- a/klayslave/config/config.go
+++ b/klayslave/config/config.go
@@ -121,7 +121,7 @@ func (cfg *Config) setConfigsFromFlag(ctx *cli.Context) {
 	if len(cfg.tcNameList) == 0 {
 		log.Fatal("No valid Tc is set. Please set valid TcList. \n Input tcList was '" + tcNames + "'")
 	}
-	if (cfg.InTheTcList("gaslessTransactionTC") || cfg.InTheTcList("gaslessRevertTransactionTC")) && (cfg.testTokenAddress == "" || cfg.gsrAddress == "") {
+	if (cfg.InTheTcList("gaslessTransactionTC") || cfg.InTheTcList("gaslessRevertTransactionTC") || cfg.InTheTcList("gaslessOnlyApproveTC")) && (cfg.testTokenAddress == "" || cfg.gsrAddress == "") {
 		log.Fatal("When executing gaslessTransactionTC, the flags: testTokenAddr and gsrAddr are required. e.g) -testTokenAddr $Address -gsrAddr $Address")
 	}
 

--- a/klayslave/main.go
+++ b/klayslave/main.go
@@ -75,7 +75,11 @@ func main() {
 func RunAction(ctx *cli.Context) {
 	cfg := config.NewConfig(ctx)
 	accGrp := account.NewAccGroup(cfg.GetChainID(), cfg.GetGasPrice(), cfg.GetBaseFee(), cfg.InTheTcList("transferUnsignedTx"))
-	accGrp.CreateAccountsPerAccGrp(cfg.GetNUserForSigned(), cfg.GetNUserForUnsigned(), cfg.GetNUserForNewAccounts(), cfg.GetTcStrList(), cfg.GetGEndpoint())
+	var nUserForGaslessRevertTx int = 0
+	if cfg.InTheTcList("gaslessRevertTransactionTC") {
+		nUserForGaslessRevertTx = cfg.GetNUserForSigned() // same as nUserForSignedTx
+	}
+	accGrp.CreateAccountsPerAccGrp(cfg.GetNUserForSigned(), cfg.GetNUserForUnsigned(), cfg.GetNUserForNewAccounts(), nUserForGaslessRevertTx, cfg.GetTcStrList(), cfg.GetGEndpoint())
 
 	createTestAccGroupsAndPrepareContracts(cfg, accGrp)
 	tasks := cfg.GetExtendedTasks()
@@ -159,6 +163,8 @@ func initializeTasks(cfg *config.Config, accGrp *account.AccGroup, tasks []*test
 		accs := accGrp.GetAccListByName(account.AccListForSignedTx)
 		if extendedTask.Name == "transferUnsignedTx" {
 			accs = accGrp.GetAccListByName(account.AccListForUnsignedTx)
+		} else if extendedTask.Name == "gaslessRevertTransactionTC" {
+			accs = accGrp.GetAccListByName(account.AccListForGaslessRevertTx)
 		}
 		extendedTask.Init(accs, cfg.GetGEndpoint(), cfg.GetGasPrice())
 		println("=> " + extendedTask.Name + " extendedTask is initialized.")

--- a/testcase/gaslessOnlyApproveTC/gaslessOnlyApproveTC.go
+++ b/testcase/gaslessOnlyApproveTC/gaslessOnlyApproveTC.go
@@ -1,0 +1,68 @@
+package gaslessOnlyApproveTC
+
+import (
+	"log"
+	"math/big"
+	"math/rand"
+
+	"github.com/kaiachain/kaia-load-tester/klayslave/account"
+	"github.com/kaiachain/kaia-load-tester/klayslave/clipool"
+	"github.com/kaiachain/kaia/client"
+	"github.com/myzhan/boomer"
+)
+
+const Name = "gaslessOnlyApproveTC"
+
+var (
+	endPoint string
+	nAcc     int
+	accGrp   []*account.Account
+	cliPool  clipool.ClientPool
+	gasPrice *big.Int
+
+	TestTokenAccount *account.Account
+	GsrAccount       *account.Account
+)
+
+func Init(accs []*account.Account, endpoint string, gp *big.Int) {
+	gasPrice = gp
+
+	endPoint = endpoint
+
+	cliCreate := func() interface{} {
+		c, err := client.Dial(endPoint)
+		if err != nil {
+			log.Fatalf("Failed to connect RPC: %v", err)
+		}
+		return c
+	}
+
+	cliPool.Init(20, 300, cliCreate)
+
+	for _, acc := range accs {
+		accGrp = append(accGrp, acc)
+	}
+
+	nAcc = len(accGrp)
+}
+
+func Run() {
+	cli := cliPool.Alloc().(*client.Client)
+
+	from := accGrp[rand.Int()%nAcc]
+	testRecordName := "TransferNewGaslessApproveTx" + " to " + endPoint
+
+	start := boomer.Now()
+
+	_, _, err := from.TransferNewGaslessApproveTx(cli, endPoint, TestTokenAccount, GsrAccount)
+
+	elapsed := boomer.Now() - start
+
+	cliPool.Free(cli)
+
+	if err != nil {
+		boomer.RecordFailure("http", testRecordName, elapsed, err.Error())
+	} else {
+		boomer.RecordSuccess("http", testRecordName, elapsed, int64(10))
+	}
+}

--- a/testcase/tclist.go
+++ b/testcase/tclist.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kaiachain/kaia-load-tester/testcase/ethereumTxAccessListTC"
 	"github.com/kaiachain/kaia-load-tester/testcase/ethereumTxDynamicFeeTC"
 	"github.com/kaiachain/kaia-load-tester/testcase/ethereumTxLegacyTC"
+	"github.com/kaiachain/kaia-load-tester/testcase/gaslessOnlyApproveTC"
 	"github.com/kaiachain/kaia-load-tester/testcase/gaslessRevertTransactionTC"
 	"github.com/kaiachain/kaia-load-tester/testcase/gaslessTransactionTC"
 	"github.com/kaiachain/kaia-load-tester/testcase/internalTxTC"
@@ -444,6 +445,12 @@ var TcList = map[string]*ExtendedTask{
 		Weight: 10,
 		Fn:     gaslessRevertTransactionTC.Run,
 		Init:   gaslessRevertTransactionTC.Init,
+	},
+	"gaslessOnlyApproveTC": {
+		Name:   gaslessOnlyApproveTC.Name,
+		Weight: 10,
+		Fn:     gaslessOnlyApproveTC.Run,
+		Init:   gaslessOnlyApproveTC.Init,
 	},
 	"ethereumTxLegacyTC": {
 		Name:   "ethereumTxLegacyTC",


### PR DESCRIPTION
## Description

This is a test case that fills the pool's GA queue by issuing a large number of Gasless Approves.
The main usage of this is to run GA test cases at the same time to check whether the other GA works, whether the queue is keeping the capacity of GA txs, etc.