### PR TITLE
account: add chargeParallel flag to boost the charging speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Parameters
 * --vuunsigned: number of accounts for unsigned transaction to use in test case.
 * --endpoint: kaia node rpc endpoint(e.g. http://localhost:8551).
 * --http.maxidleconns: maximum number of idle connections in default http client (default 100).
+* --chargeParallel: number of parallel transactions for charging accounts (default: 0, auto-detect based on CPU cores). Controls concurrency when funding test accounts with KLAY and tokens.
 
 ## How to contribute?
 * issue: Please make an issue if there's bug, improvement, docs suggestion, etc.

--- a/klayslave/account/accgroup.go
+++ b/klayslave/account/accgroup.go
@@ -152,9 +152,9 @@ func (a *AccGroup) DeployTestContracts(tcList []string, localReservoir *Account,
 		if TestContract(idx) == ContractErc20 {
 			log.Printf("Start erc20 token charging to the test account group")
 			TestContractInfos[ContractErc20].deployer.SmartContractExecutionWithGuaranteeRetry(gCli, a.contracts[ContractErc20], TestContractInfos[ContractErc20].GenData(localReservoir.address, big.NewInt(1e11)))
-			ConcurrentTransactionSend(a.GetValidAccGrp(), func(acc *Account) {
+			ConcurrentTransactionSend(a.GetValidAccGrp(), maxConcurrency, func(acc *Account) {
 				localReservoir.SmartContractExecutionWithGuaranteeRetry(gCli, a.contracts[ContractErc20], TestContractInfos[ContractErc20].GenData(acc.address, big.NewInt(1e4)))
-			}, maxConcurrency)
+			})
 		} else if TestContract(idx) == ContractErc721 {
 			log.Printf("Start erc721 nft minting to the test account group(similar to erc20 token charging)")
 			localReservoir.MintERC721ToTestAccounts(gCli, a.GetValidAccGrp(), a.GetTestContractByName(ContractErc721).GetAddress(), 5)
@@ -169,9 +169,9 @@ func (a *AccGroup) DeployTestContracts(tcList []string, localReservoir *Account,
 			// accounts(validAccGrp + gaslessApproveAccGrp) should be charged.
 			accounts := a.GetValidAccGrp()
 			accounts = append(accounts, a.GetAccListByName(AccListForGaslessApproveTx)...)
-			ConcurrentTransactionSend(accounts, func(acc *Account) {
+			ConcurrentTransactionSend(accounts, maxConcurrency, func(acc *Account) {
 				localReservoir.SmartContractExecutionWithGuaranteeRetry(gCli, a.contracts[ContractGaslessToken], TestContractInfos[ContractErc20].GenData(acc.address, chargeValue))
-			}, maxConcurrency)
+			})
 		}
 	}
 }

--- a/klayslave/account/accgroup.go
+++ b/klayslave/account/accgroup.go
@@ -120,7 +120,7 @@ func (a *AccGroup) GetValidAccGrp() []*Account {
 	return accGrp
 }
 
-func (a *AccGroup) DeployTestContracts(tcList []string, localReservoir *Account, gCli *client.Client, chargeValue *big.Int) {
+func (a *AccGroup) DeployTestContracts(tcList []string, localReservoir *Account, gCli *client.Client, chargeValue *big.Int, maxConcurrency int) {
 	inTheTcList := func(testNames []string) bool {
 		for _, tcName := range tcList {
 			for _, target := range testNames {
@@ -154,7 +154,7 @@ func (a *AccGroup) DeployTestContracts(tcList []string, localReservoir *Account,
 			TestContractInfos[ContractErc20].deployer.SmartContractExecutionWithGuaranteeRetry(gCli, a.contracts[ContractErc20], TestContractInfos[ContractErc20].GenData(localReservoir.address, big.NewInt(1e11)))
 			ConcurrentTransactionSend(a.GetValidAccGrp(), func(acc *Account) {
 				localReservoir.SmartContractExecutionWithGuaranteeRetry(gCli, a.contracts[ContractErc20], TestContractInfos[ContractErc20].GenData(acc.address, big.NewInt(1e4)))
-			})
+			}, maxConcurrency)
 		} else if TestContract(idx) == ContractErc721 {
 			log.Printf("Start erc721 nft minting to the test account group(similar to erc20 token charging)")
 			localReservoir.MintERC721ToTestAccounts(gCli, a.GetValidAccGrp(), a.GetTestContractByName(ContractErc721).GetAddress(), 5)
@@ -171,7 +171,7 @@ func (a *AccGroup) DeployTestContracts(tcList []string, localReservoir *Account,
 			accounts = append(accounts, a.GetAccListByName(AccListForGaslessApproveTx)...)
 			ConcurrentTransactionSend(accounts, func(acc *Account) {
 				localReservoir.SmartContractExecutionWithGuaranteeRetry(gCli, a.contracts[ContractGaslessToken], TestContractInfos[ContractErc20].GenData(acc.address, chargeValue))
-			})
+			}, maxConcurrency)
 		}
 	}
 }

--- a/klayslave/account/account.go
+++ b/klayslave/account/account.go
@@ -2150,7 +2150,7 @@ func (a *Account) CheckBalance(expectedBalance *big.Int, cli *client.Client) err
 	return nil
 }
 
-func ConcurrentTransactionSend(accs []*Account, transactionSend func(*Account), maxConcurrency int) {
+func ConcurrentTransactionSend(accs []*Account, maxConcurrency int, transactionSend func(*Account)) {
 	if maxConcurrency <= 0 {
 		maxConcurrency = runtime.NumCPU() * 10 // default value
 	}

--- a/klayslave/account/account.go
+++ b/klayslave/account/account.go
@@ -2150,8 +2150,11 @@ func (a *Account) CheckBalance(expectedBalance *big.Int, cli *client.Client) err
 	return nil
 }
 
-func ConcurrentTransactionSend(accs []*Account, transactionSend func(*Account)) {
-	ch := make(chan int, runtime.NumCPU()*10)
+func ConcurrentTransactionSend(accs []*Account, transactionSend func(*Account), maxConcurrency int) {
+	if maxConcurrency <= 0 {
+		maxConcurrency = runtime.NumCPU() * 10 // default value
+	}
+	ch := make(chan int, maxConcurrency)
 	wg := sync.WaitGroup{}
 	for _, acc := range accs {
 		ch <- 1

--- a/klayslave/config/config.go
+++ b/klayslave/config/config.go
@@ -124,6 +124,7 @@ func (cfg *Config) setConfigsFromFlag(ctx *cli.Context) {
 	fmt.Printf("- activeUserPercent = %v\n", cfg.activeUserPercent)
 	fmt.Printf("- coinbasePrivatekey = %v\n", cfg.richWalletPrivateKey)
 	fmt.Printf("- charging KLAY Amount = %v\n", cfg.chargeKLAYAmount)
+	fmt.Printf("- chargeParallel = %v\n", cfg.chargeParallelNum)
 	fmt.Printf("- tc = %v\n", cfg.tcNameList)
 	fmt.Printf("- weights = %v\n", cfg.tcWeights)
 }
@@ -199,6 +200,7 @@ func (cfg *Config) GetActiveUserPercent() int       { return cfg.activeUserPerce
 func (cfg *Config) GetTcStrList() []string          { return cfg.tcNameList }
 func (cfg *Config) GetRichWalletPrivateKey() string { return cfg.richWalletPrivateKey }
 func (cfg *Config) GetGCli() *klay.Client           { return cfg.gCli }
+func (cfg *Config) GetChargeParallelNum() int       { return cfg.chargeParallelNum }
 func (cfg *Config) InTheTcList(tcName string) bool {
 	for _, tc := range cfg.tcNameList {
 		if tcName == tc {
@@ -222,6 +224,7 @@ var Flags = []cli.Flag{
 	//cli.IntFlag{Name: "acc.nUserForNewAccounts", Value: 5, Usage: "num of new accounts"}, // TODO-kaia-load-tester: find out what this value for
 	cli.IntFlag{Name: "activeUserPercent", Value: 100, Usage: "percent of active accounts"},
 	cli.IntFlag{Name: "charge", Value: 1000000000, Usage: "charging amount for each test account in KLAY"},
+	cli.IntFlag{Name: "chargeParallel", Value: 0, Usage: "number of parallel transactions for charging accounts (0 = auto-detect based on CPU cores)"},
 	cli.IntFlag{Name: "maxidleconns", Value: 100, Usage: "maximum number of idle connections in default http client"},
 	cli.StringFlag{Name: "key", Usage: "private key of rich account for kaia charging of test accounts"},
 	cli.StringFlag{Name: "tc", Value: "", Usage: "tasks which user want to run, multiple tasks are separated by comma."},

--- a/klayslave/main.go
+++ b/klayslave/main.go
@@ -147,7 +147,7 @@ func createTestAccGroupsAndPrepareContracts(cfg *config.Config, accGrp *account.
 	accs = append(accs, accGrp.GetAccListByName(account.AccListForGaslessApproveTx)...) // for avoid validation
 	account.ConcurrentTransactionSend(accs, func(acc *account.Account) {
 		localReservoirAccount.TransferSignedTxWithGuaranteeRetry(cfg.GetGCli(), acc, cfg.GetChargeValue())
-	})
+	}, cfg.GetChargeParallelNum())
 	log.Printf("Finished charging KLAY to %d test account(s)\n", len(accs))
 
 	// Wait, charge KAIA happen in 100% of all created test accounts
@@ -155,7 +155,7 @@ func createTestAccGroupsAndPrepareContracts(cfg *config.Config, accGrp *account.
 	accGrp.SetAccGrpByActivePercent(cfg.GetActiveUserPercent())
 
 	// 4. Deploy the test contracts which will be used in various TCs. If needed, charge tokens to test accounts.
-	accGrp.DeployTestContracts(cfg.GetTcStrList(), localReservoirAccount, cfg.GetGCli(), cfg.GetChargeValue())
+	accGrp.DeployTestContracts(cfg.GetTcStrList(), localReservoirAccount, cfg.GetGCli(), cfg.GetChargeValue(), cfg.GetChargeParallelNum())
 	if !account.IsGSRExistInRegistry(cfg.GetGCli()) && (cfg.InTheTcList("gaslessTransactionTC") || cfg.InTheTcList("gaslessRevertTransactionTC") || cfg.InTheTcList("gaslessOnlyApproveTC")) {
 		log.Printf("GSR does not exist in registry, setting up liquidity and registering GSR...")
 
@@ -173,6 +173,7 @@ func createTestAccGroupsAndPrepareContracts(cfg *config.Config, accGrp *account.
 		// Register GSR
 		account.RegisterGSR(cfg.GetGCli(), accGrp, globalReservoirAccount)
 	}
+	accGrp.DeployTestContracts(cfg.GetTcStrList(), localReservoirAccount, cfg.GetGCli(), cfg.GetChargeValue(), cfg.GetChargeParallelNum())
 
 	// Set SmartContractAddress value in each packages if needed
 	setSmartContractAddressPerPackage(accGrp)

--- a/klayslave/main.go
+++ b/klayslave/main.go
@@ -145,9 +145,9 @@ func createTestAccGroupsAndPrepareContracts(cfg *config.Config, accGrp *account.
 	accs := accGrp.GetValidAccGrp()
 	accs = append(accs, accGrp.GetAccListByName(account.AccListForGaslessRevertTx)...)  // for avoid validation
 	accs = append(accs, accGrp.GetAccListByName(account.AccListForGaslessApproveTx)...) // for avoid validation
-	account.ConcurrentTransactionSend(accs, func(acc *account.Account) {
+	account.ConcurrentTransactionSend(accs, cfg.GetChargeParallelNum(), func(acc *account.Account) {
 		localReservoirAccount.TransferSignedTxWithGuaranteeRetry(cfg.GetGCli(), acc, cfg.GetChargeValue())
-	}, cfg.GetChargeParallelNum())
+	})
 	log.Printf("Finished charging KLAY to %d test account(s)\n", len(accs))
 
 	// Wait, charge KAIA happen in 100% of all created test accounts


### PR DESCRIPTION
This PR adds `chargeParallel` flag to set the number of parallel transactions for charging accounts. Default is 0, auto-detect based on CPU cores.