### PR TITLE
auction: Increase error range for auctionBidTC

### DIFF
--- a/klayslave/account/account.go
+++ b/klayslave/account/account.go
@@ -1962,6 +1962,12 @@ func (self *Account) AuctionBid(c *client.Client, endpoint string, auctionEntryP
 
 	gas := uint64(5000000)
 
+	// Get entrypoint nonce
+	appNonce := getEntrypointNonce(c, self.GetAddress())
+
+	// Create contract call data (CounterForAuction.incForAuction())
+	contractCallData := TestContractInfos[ContractCounterForTestAuction].GenData(common.Address{}, common.Big0) // 0 means calling incForAuction()
+
 	// Get current block number
 	blockNumber, err := c.BlockNumber(ctx)
 	if err != nil {
@@ -1970,12 +1976,6 @@ func (self *Account) AuctionBid(c *client.Client, endpoint string, auctionEntryP
 	if self.isLastBlocknumSentTx(blockNumber.Uint64()) {
 		return common.Hash{0}, common.Hash{0}, suggestedGasPrice, errors.New("this account has already sent a tx for the block")
 	}
-
-	// Get entrypoint nonce
-	appNonce := getEntrypointNonce(c, self.GetAddress())
-
-	// Create contract call data (CounterForAuction.incForAuction())
-	contractCallData := TestContractInfos[ContractCounterForTestAuction].GenData(common.Address{}, common.Big0) // 0 means calling incForAuction()
 
 	// Create the bid
 	bid := &auction.Bid{
@@ -2014,12 +2014,15 @@ func (self *Account) AuctionBid(c *client.Client, endpoint string, auctionEntryP
 	if rpcOutput[auctionImpl.RPC_AUCTION_ERROR_PROP] != nil {
 		submitErr = rpcOutput[auctionImpl.RPC_AUCTION_ERROR_PROP].(string)
 	}
-	if submitErr != auction.ErrInvalidTargetTxHash.Error() && isAuctionErr(submitErr) {
-		// If the error happens in auction, we need to add native nonce of searcher.
-		targetTxType.PostSendBid(c, self, tmpAccount, nonce, suggestedGasPrice, blockNumber)
-		fmt.Printf("Auction error: %v\n", submitErr)
-		return targetTx.Hash(), bid.Hash(), suggestedGasPrice, err
+	if submitErr != "" {
+		if submitErr == blockchain.ErrNonceTooLow.Error() || submitErr == blockchain.ErrReplaceUnderpriced.Error() {
+			fmt.Printf("Account(%v) nonce(%v) : Failed to sendTransaction: %v\n", self.GetAddress().String(), nonce, submitErr)
+			fmt.Printf("Account(%v) nonce is added to %v\n", self.GetAddress().String(), nonce+1)
+			self.nonce++
+		}
+		return targetTx.Hash(), bid.Hash(), suggestedGasPrice, errors.New(submitErr)
 	}
+
 	targetTxType.PostSendBid(c, self, tmpAccount, nonce, suggestedGasPrice, blockNumber)
 
 	return targetTx.Hash(), bid.Hash(), suggestedGasPrice, nil
@@ -2058,6 +2061,9 @@ func (self *Account) AuctionRevertedBid(c *client.Client, endpoint string, aucti
 
 	gas := uint64(5000000)
 
+	// Create contract call data (CounterForAuction.incForAuction())
+	contractCallData := TestContractInfos[ContractCounterForTestAuction].GenData(common.Address{}, common.Big0) // 0 means calling incForAuction()
+
 	// Get current block number
 	blockNumber, err := c.BlockNumber(ctx)
 	if err != nil {
@@ -2066,9 +2072,6 @@ func (self *Account) AuctionRevertedBid(c *client.Client, endpoint string, aucti
 	if self.isLastBlocknumSentTx(blockNumber.Uint64()) {
 		return common.Hash{0}, common.Hash{0}, suggestedGasPrice, errors.New("this account has already sent a tx for the block")
 	}
-
-	// Create contract call data (CounterForAuction.incForAuction())
-	contractCallData := TestContractInfos[ContractCounterForTestAuction].GenData(common.Address{}, common.Big0) // 0 means calling incForAuction()
 
 	// Create the bid
 	bid := &auction.Bid{
@@ -2107,12 +2110,15 @@ func (self *Account) AuctionRevertedBid(c *client.Client, endpoint string, aucti
 	if rpcOutput[auctionImpl.RPC_AUCTION_ERROR_PROP] != nil {
 		submitErr = rpcOutput[auctionImpl.RPC_AUCTION_ERROR_PROP].(string)
 	}
-	if submitErr != auction.ErrInvalidTargetTxHash.Error() && isAuctionErr(submitErr) {
-		// If the error happens in auction, we need to add native nonce of searcher.
-		targetTxType.PostSendBid(c, self, tmpAccount, nonce, suggestedGasPrice, blockNumber)
-		fmt.Printf("Auction error: %v\n", submitErr)
-		return targetTx.Hash(), bid.Hash(), suggestedGasPrice, err
+	if submitErr != "" {
+		if submitErr == blockchain.ErrNonceTooLow.Error() || submitErr == blockchain.ErrReplaceUnderpriced.Error() {
+			fmt.Printf("Account(%v) nonce(%v) : Failed to sendTransaction: %v\n", self.GetAddress().String(), nonce, submitErr)
+			fmt.Printf("Account(%v) nonce is added to %v\n", self.GetAddress().String(), nonce+1)
+			self.nonce++
+		}
+		return targetTx.Hash(), bid.Hash(), suggestedGasPrice, errors.New(submitErr)
 	}
+
 	targetTxType.PostSendBid(c, self, tmpAccount, nonce, suggestedGasPrice, blockNumber)
 
 	return targetTx.Hash(), bid.Hash(), suggestedGasPrice, nil


### PR DESCRIPTION
# Description

Previously, when an auction error occurred, `PostSendBid` was executed.
Since other errors were ignored, I changed it so that it would add a nonce and return it when the nonce was too low or replaced, just like other tx sends.

This prevents incorrect nonce increments and allows us to continue generating more valid tx.