### PR TITLE
testcase: fix erc20TransferTC to work when multiple test runs

### DIFF
--- a/klayslave/account/accgroup.go
+++ b/klayslave/account/accgroup.go
@@ -168,8 +168,9 @@ func (a *AccGroup) DeployTestContracts(tcList []string, targetTxTypeList []strin
 		// additional work - erc20 token charging or erc721 minting
 		if TestContract(idx) == ContractErc20 {
 			log.Printf("Start erc20 token charging to the test account group")
+			TestContractInfos[ContractErc20].deployer.SmartContractExecutionWithGuaranteeRetry(gCli, a.contracts[ContractErc20], nil, TestContractInfos[ContractErc20].GenData(localReservoir.address, big.NewInt(1e11)))
 			ConcurrentTransactionSend(a.GetValidAccGrp(), maxConcurrency, func(acc *Account) {
-				TestContractInfos[ContractErc20].deployer.SmartContractExecutionWithGuaranteeRetry(gCli, a.contracts[ContractErc20], nil, TestContractInfos[ContractErc20].GenData(acc.address, big.NewInt(1e4)))
+				localReservoir.SmartContractExecutionWithGuaranteeRetry(gCli, a.contracts[ContractErc20], nil, TestContractInfos[ContractErc20].GenData(acc.address, big.NewInt(1e4)))
 			})
 		} else if TestContract(idx) == ContractErc721 {
 			log.Printf("Start erc721 nft minting to the test account group(similar to erc20 token charging)")

--- a/klayslave/account/accgroup.go
+++ b/klayslave/account/accgroup.go
@@ -168,9 +168,8 @@ func (a *AccGroup) DeployTestContracts(tcList []string, targetTxTypeList []strin
 		// additional work - erc20 token charging or erc721 minting
 		if TestContract(idx) == ContractErc20 {
 			log.Printf("Start erc20 token charging to the test account group")
-			TestContractInfos[ContractErc20].deployer.SmartContractExecutionWithGuaranteeRetry(gCli, a.contracts[ContractErc20], nil, TestContractInfos[ContractErc20].GenData(localReservoir.address, big.NewInt(1e11)))
 			ConcurrentTransactionSend(a.GetValidAccGrp(), maxConcurrency, func(acc *Account) {
-				localReservoir.SmartContractExecutionWithGuaranteeRetry(gCli, a.contracts[ContractErc20], nil, TestContractInfos[ContractErc20].GenData(acc.address, big.NewInt(1e4)))
+				TestContractInfos[ContractErc20].deployer.SmartContractExecutionWithGuaranteeRetry(gCli, a.contracts[ContractErc20], nil, TestContractInfos[ContractErc20].GenData(acc.address, big.NewInt(1e4)))
 			})
 		} else if TestContract(idx) == ContractErc721 {
 			log.Printf("Start erc721 nft minting to the test account group(similar to erc20 token charging)")

--- a/klayslave/account/contract.go
+++ b/klayslave/account/contract.go
@@ -108,7 +108,7 @@ func createERC20ContractInfo() TestContractInfo {
 			if err != nil {
 				log.Fatalf("failed to abi.JSON: %v", err)
 			}
-			data, err := abii.Pack("transfer", recipientAddr, value)
+			data, err := abii.Pack("mint", recipientAddr, value)
 			if err != nil {
 				log.Fatalf("failed to abi.Pack: %v", err)
 			}

--- a/klayslave/account/contract.go
+++ b/klayslave/account/contract.go
@@ -55,11 +55,12 @@ var (
 
 // TestContractInfo represents a test contract configuration
 type TestContractInfo struct {
-	testNames                       []string
-	auctionTargetTxTypeList         []string
-	Bytecode                        []byte
-	deployer                        *Account
-	contractName                    string
+	testNames               []string
+	auctionTargetTxTypeList []string
+	Bytecode                []byte
+	deployer                *Account
+	contractName            string
+	// TODO: make GenData array or use go wrapper file
 	GenData                         func(addr common.Address, value *big.Int) []byte
 	GetBytecodeWithConstructorParam func(bin []byte, contracts []*Account, deployer *Account) []byte
 	ShouldDeploy                    func(gCli *client.Client, deployer *Account) bool
@@ -108,7 +109,12 @@ func createERC20ContractInfo() TestContractInfo {
 			if err != nil {
 				log.Fatalf("failed to abi.JSON: %v", err)
 			}
-			data, err := abii.Pack("mint", recipientAddr, value)
+			var data []byte
+			if value.Cmp(big.NewInt(1e11)) == 0 {
+				data, err = abii.Pack("mint", recipientAddr, value)
+			} else {
+				data, err = abii.Pack("transfer", recipientAddr, value)
+			}
 			if err != nil {
 				log.Fatalf("failed to abi.Pack: %v", err)
 			}


### PR DESCRIPTION
This PR changes the erc20 token charging process. Previously, it transfers the token, but after several restart of slaves, all tokens gone. This PR changes to `mint` the token instead of `transfer` the token.