### PR TITLE
Improve auction bid insert rate

### DIFF
--- a/klayslave/account/accgroup.go
+++ b/klayslave/account/accgroup.go
@@ -230,6 +230,12 @@ func (a *AccountSet) GetAccountRandomly() *Account {
 	return a.accounts[rand.Int()%a.Len()]
 }
 
+func (a *AccountSet) GetAccountIndex(index int) *Account {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.accounts[index]
+}
+
 func (a *AccountSet) GetAccountRoundRobin() *Account {
 	a.mu.Lock()
 	defer a.mu.Unlock()

--- a/klayslave/account/account.go
+++ b/klayslave/account/account.go
@@ -1961,7 +1961,7 @@ func (self *Account) AuctionBid(c *client.Client, auctionEntryPoint, targetContr
 			fmt.Printf("Account(%v) nonce is added to %v\n", self.GetAddress().String(), nonce+1)
 			self.nonce++
 		}
-		return targetTx.Hash(), common.Hash{0}, suggestedGasPrice, errors.New("failed to send auction bid")
+		return targetTx.Hash(), common.Hash{0}, suggestedGasPrice, fmt.Errorf("failed to send auction bid: %v", submitErr)
 	}
 
 	targetTxType.PostSendBid(c, self, tmpAccount, nonce, suggestedGasPrice, blockNumber)

--- a/testcase/run_auction.go
+++ b/testcase/run_auction.go
@@ -19,7 +19,8 @@ func RunBaseWithAuction(config *TCConfig, auctionTxFunc AuctionTxFunc) func() {
 		cli := config.CliPool.Alloc().(*client.Client)
 		defer config.CliPool.Free(cli)
 
-		from := config.AccGrp[rand.Int()%config.NAcc]
+		// Use round robin to avoid the same account being used too often
+		from := config.AccGrp.GetAccountRoundRobin()
 
 		auctionEntryPoint := config.SmartContractAccounts[account.ContractAuctionEntryPoint]
 		targetContract := config.SmartContractAccounts[account.ContractCounterForTestAuction]

--- a/testcase/run_ethereum.go
+++ b/testcase/run_ethereum.go
@@ -70,7 +70,7 @@ func createRandomArguments(config *TCConfig, addr common.Address) (*account.Acco
 
 	var err error
 	if randomLegacyReqType == 0 {
-		to = config.AccGrp[rand.Int()%config.NAcc]
+		to = config.AccGrp.GetAccountRandomly()
 		value = big.NewInt(int64(rand.Int() % 3))
 	} else if randomLegacyReqType == 1 {
 		value = big.NewInt(0)
@@ -185,7 +185,7 @@ func RunEthereumTxLegacyTC(config *TCConfig) func() {
 		cli := config.CliPool.Alloc().(*client.Client)
 		defer config.CliPool.Free(cli)
 
-		from := config.AccGrp[rand.Int()%config.NAcc]
+		from := config.AccGrp.GetAccountRandomly()
 		to, value, input, reqType, err := createRandomArguments(config, from.GetAddress())
 		if err != nil {
 			fmt.Printf("Failed to create arguments to send Legacy Tx: %v\n", err.Error())
@@ -222,7 +222,7 @@ func RunEthereumTxAccessListTC(config *TCConfig) func() {
 		cli := config.CliPool.Alloc().(*client.Client)
 		defer config.CliPool.Free(cli)
 
-		from := config.AccGrp[rand.Int()%config.NAcc]
+		from := config.AccGrp.GetAccountRandomly()
 		to, value, input, reqType, err := createRandomArguments(config, from.GetAddress())
 		if err != nil {
 			fmt.Printf("Failed to create arguments to send Access List Tx: %v\n", err.Error())
@@ -259,7 +259,7 @@ func RunEthereumTxDynamicFeeTC(config *TCConfig) func() {
 		cli := config.CliPool.Alloc().(*client.Client)
 		defer config.CliPool.Free(cli)
 
-		from := config.AccGrp[rand.Int()%config.NAcc]
+		from := config.AccGrp.GetAccountRandomly()
 		to, value, input, reqType, err := createRandomArguments(config, from.GetAddress())
 		if err != nil {
 			fmt.Printf("Failed to create arguments to send Dynamic Fee Tx: %v\n", err.Error())
@@ -296,7 +296,7 @@ func RunNewEthereumAccessListTC(config *TCConfig) func() {
 		cli := config.CliPool.Alloc().(*client.Client)
 		defer config.CliPool.Free(cli)
 
-		from := config.AccGrp[rand.Int()%config.NAcc]
+		from := config.AccGrp.GetAccountRandomly()
 		to, value, input, reqType, err := createRandomArguments(config, from.GetAddress())
 		if err != nil {
 			fmt.Printf("Failed to create arguments to send Access List Tx: %v\n", err.Error())
@@ -331,7 +331,7 @@ func RunNewEthereumDynamicFeeTC(config *TCConfig) func() {
 		cli := config.CliPool.Alloc().(*client.Client)
 		defer config.CliPool.Free(cli)
 
-		from := config.AccGrp[rand.Int()%config.NAcc]
+		from := config.AccGrp.GetAccountRandomly()
 		to, value, input, reqType, err := createRandomArguments(config, from.GetAddress())
 		if err != nil {
 			fmt.Printf("Failed to create arguments to send Dynamic Fee Tx: %v\n", err.Error())

--- a/testcase/run_execute_contract.go
+++ b/testcase/run_execute_contract.go
@@ -18,7 +18,7 @@ func RunBaseWithContract(config *TCConfig, txFunc SmartContractTxFunc) func() {
 		cli := config.CliPool.Alloc().(*client.Client)
 		defer config.CliPool.Free(cli)
 
-		from := config.AccGrp[rand.Int()%config.NAcc]
+		from := config.AccGrp.GetAccountRandomly()
 		to := config.SmartContractAccounts[config.TestContracts[0]]
 
 		start := boomer.Now()
@@ -88,24 +88,24 @@ func RunErc721TransferTC(config *TCConfig) func() {
 		cli := config.CliPool.Alloc().(*client.Client)
 		defer config.CliPool.Free(cli)
 
-		toAcc := config.AccGrp[rand.Intn(config.NAcc)]
+		toAcc := config.AccGrp.GetAccountRandomly()
 
 		// Find an account with available tokens
 		var fromAcc *account.Account
 		var tokenId *big.Int
 
 		// Try multiple accounts to find one with tokens
-		candidateIdx := rand.Intn(len(config.AccGrp))
+		candidateIdx := rand.Intn(config.AccGrp.Len())
 
 		// limit the number of attempts to find a token
-		for i := 0; i < len(config.AccGrp); i++ {
-			candidateAcc := config.AccGrp[candidateIdx]
+		for i := 0; i < config.AccGrp.Len(); i++ {
+			candidateAcc := config.AccGrp.GetAccountIndex(candidateIdx)
 			tokenId = account.ERC721Ledger.RemoveToken(candidateAcc.GetAddress())
 			if tokenId != nil {
 				fromAcc = candidateAcc
 				break
 			}
-			candidateIdx = (candidateIdx + 1) % len(config.AccGrp)
+			candidateIdx = (candidateIdx + 1) % config.AccGrp.Len()
 		}
 
 		if tokenId == nil {
@@ -221,7 +221,7 @@ func RunUserStorageSetGetTC(config *TCConfig) func() {
 	return func() {
 		cli := config.CliPool.Alloc().(*client.Client)
 		defer config.CliPool.Free(cli)
-		from := config.AccGrp[rand.Int()%config.NAcc]
+		from := config.AccGrp.GetAccountRandomly()
 
 		start := boomer.Now()
 

--- a/testcase/run_read_api_call.go
+++ b/testcase/run_read_api_call.go
@@ -118,7 +118,7 @@ func RunGetAccount(config *TCConfig) func() {
 		rpcCli := config.RpcCliPool.Alloc().(*rpc.Client)
 		defer config.RpcCliPool.Free(rpcCli)
 
-		fromAccount := config.AccGrp[rand.Int()%config.NAcc]
+		fromAccount := config.AccGrp.GetAccountRandomly()
 		start := boomer.Now()
 
 		var j json.RawMessage
@@ -188,7 +188,7 @@ func RunCall(config *TCConfig) func() {
 		cli := config.CliPool.Alloc().(*client.Client)
 		defer config.CliPool.Free(cli)
 
-		fromAccount := config.AccGrp[rand.Int()%config.NAcc].GetAddress()
+		fromAccount := config.AccGrp.GetAccountRandomly().GetAddress()
 		contractAddr := config.SmartContractAccounts[account.ContractReadApiCallContract].GetAddress()
 		data := account.TestContractInfos[account.ContractReadApiCallContract].GenData(fromAccount, big.NewInt(0))
 
@@ -225,7 +225,7 @@ func RunEstimateGas(config *TCConfig) func() {
 		cli := config.CliPool.Alloc().(*client.Client)
 		defer config.CliPool.Free(cli)
 
-		fromAccount := config.AccGrp[rand.Int()%config.NAcc].GetAddress()
+		fromAccount := config.AccGrp.GetAccountRandomly().GetAddress()
 		contractAddr := config.SmartContractAccounts[account.ContractReadApiCallContract].GetAddress()
 		data := account.TestContractInfos[account.ContractReadApiCallContract].GenData(fromAccount, big.NewInt(1))
 

--- a/testcase/run_receipt_check.go
+++ b/testcase/run_receipt_check.go
@@ -89,8 +89,8 @@ func runReceiptCheckSendTx(config *TCConfig) func() {
 		cli := config.CliPool.Alloc().(*client.Client)
 		defer config.CliPool.Free(cli)
 
-		from := config.AccGrp[rand.Int()%config.NAcc]
-		to := config.AccGrp[rand.Int()%config.NAcc]
+		from := config.AccGrp.GetAccountRandomly()
+		to := config.AccGrp.GetAccountRandomly()
 		value := big.NewInt(int64(rand.Int() % 3))
 
 		start := boomer.Now()
@@ -237,8 +237,8 @@ func RunTransferSignedWithCheckTC(config *TCConfig) func() {
 		cli := config.CliPool.Alloc().(*client.Client)
 		defer config.CliPool.Free(cli)
 
-		from := config.AccGrp[rand.Int()%config.NAcc]
-		to := config.AccGrp[rand.Int()%config.NAcc]
+		from := config.AccGrp.GetAccountRandomly()
+		to := config.AccGrp.GetAccountRandomly()
 
 		value := big.NewInt(int64(rand.Int() % 3))
 		start := boomer.Now()

--- a/testcase/run_value_transfer.go
+++ b/testcase/run_value_transfer.go
@@ -18,8 +18,8 @@ func RunBaseValueTransfer(config *TCConfig, txFunc ValueTransferTxFunc) func() {
 		cli := config.CliPool.Alloc().(*client.Client)
 		defer config.CliPool.Free(cli)
 
-		from := config.AccGrp[rand.Int()%config.NAcc]
-		to := config.AccGrp[rand.Int()%config.NAcc]
+		from := config.AccGrp.GetAccountRandomly()
+		to := config.AccGrp.GetAccountRandomly()
 		value := big.NewInt(int64(rand.Int() % 3))
 
 		start := boomer.Now()

--- a/testcase/tcconfig.go
+++ b/testcase/tcconfig.go
@@ -13,8 +13,7 @@ import (
 type TCConfig struct {
 	Name                    string
 	EndPoint                string
-	NAcc                    int
-	AccGrp                  []*account.Account
+	AccGrp                  *account.AccountSet
 	CliPool                 clipool.ClientPool
 	RpcCliPool              clipool.ClientPool                        // For RPC client (used by specific Read API test cases)
 	SmartContractAccounts   map[account.TestContract]*account.Account // For multiple contracts
@@ -61,10 +60,8 @@ func Init(accGrp *account.AccGroup, endpoint string, testContracts []account.Tes
 		accs = accGrp.GetAccListByName(account.AccListForGaslessApproveTx)
 	}
 	for _, acc := range accs {
-		config.AccGrp = append(config.AccGrp, acc)
+		config.AccGrp.Add(acc)
 	}
-
-	config.NAcc = len(config.AccGrp)
 
 	// Set SmartContractAccounts if a specific contract is required
 	contractsParam := accGrp.GetTestContractList()

--- a/testcase/tcconfig.go
+++ b/testcase/tcconfig.go
@@ -59,9 +59,8 @@ func Init(accGrp *account.AccGroup, endpoint string, testContracts []account.Tes
 	} else if tcName == "gaslessOnlyApproveTC" {
 		accs = accGrp.GetAccListByName(account.AccListForGaslessApproveTx)
 	}
-	for _, acc := range accs {
-		config.AccGrp.Add(acc)
-	}
+
+	config.AccGrp = account.NewAccountSet(accs)
 
 	// Set SmartContractAccounts if a specific contract is required
 	contractsParam := accGrp.GetTestContractList()


### PR DESCRIPTION
# Description

This PR improves auction bid insert rate.

**How much improvement will there be?**
The average time per auction tx in a 1000RPS environment is slightly improved.
123 -> 130

**Changes**

- Change auctionTC to send multiple bids
- Change AccGrp in tcconfig to AcountSet
  - In #26, the auction from selection algorithm was unintentionally changed to random, so it was reverted to round robin.
- Error handling policy
  - success: When at least one SubmitBid is executed without any errors
  - error:
    - Other than success
    - In particular, if all errors are related to nonce too low, increment the nonce of self.