### PR TITLE
Add Erc20TransferWithBlockedListTC test case

### DIFF
--- a/klayslave/account/accgroup.go
+++ b/klayslave/account/accgroup.go
@@ -20,6 +20,7 @@ const (
 	AccListForNewAccounts
 	AccListForGaslessRevertTx
 	AccListForGaslessApproveTx
+	AccListForTC
 	AccListEnd
 )
 
@@ -46,6 +47,8 @@ const (
 	ContractUserStorage
 	ContractInternalTxKIP17
 	ContractInternalTxMain
+	ContractTetherLogic
+	ContractTetherProxy
 	ContractEnd
 )
 
@@ -84,8 +87,8 @@ func (a *AccGroup) SetAccListByName(accs []*Account, t AccList) {
 func (a *AccGroup) AddAccToListByName(acc *Account, t AccList) {
 	a.accLists[t] = append(a.accLists[t], acc)
 }
-func (a *AccGroup) CreateAccountsPerAccGrp(nUserForSignedTx int, nUserForUnsignedTx int, nUserForNewAccounts int, nUserForGaslessRevertTx int, nUserForGaslessApproveTx int, tcStrList []string, gEndpoint string) {
-	for idx, nUser := range []int{nUserForSignedTx, nUserForUnsignedTx, nUserForNewAccounts, nUserForGaslessRevertTx, nUserForGaslessApproveTx} {
+func (a *AccGroup) CreateAccountsPerAccGrp(nUserForSignedTx int, nUserForUnsignedTx int, nUserForNewAccounts int, nUserForGaslessRevertTx int, nUserForGaslessApproveTx int, nUserForTC int, tcStrList []string, gEndpoint string) {
+	for idx, nUser := range []int{nUserForSignedTx, nUserForUnsignedTx, nUserForNewAccounts, nUserForGaslessRevertTx, nUserForGaslessApproveTx, nUserForTC} {
 		println(idx, " Account Group Preparation...")
 		for i := 0; i < nUser; i++ {
 			account := NewAccount(i)

--- a/klayslave/account/account.go
+++ b/klayslave/account/account.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	kaia "github.com/kaiachain/kaia"
@@ -1539,14 +1540,34 @@ func ConcurrentTransactionSend(accs []*Account, maxConcurrency int, transactionS
 	if maxConcurrency <= 0 {
 		maxConcurrency = runtime.NumCPU() * 10 // default value
 	}
+
+	total := len(accs)
+	if total == 0 {
+		return
+	}
+
+	var completed int64
 	ch := make(chan int, maxConcurrency)
 	wg := sync.WaitGroup{}
+
+	// Progress reporting interval (every 10% or minimum 1)
+	reportInterval := total / 10
+	if reportInterval == 0 {
+		reportInterval = 1
+	}
+
 	for idx, acc := range accs {
 		ch <- 1
 		wg.Add(1)
 		go func() {
 			transactionSend(idx, acc)
 			<-ch
+
+			current := atomic.AddInt64(&completed, 1)
+			if current%int64(reportInterval) == 0 || current == int64(total) {
+				log.Printf("Progress: %d/%d (%.1f%%)", current, total, float64(current)/float64(total)*100)
+			}
+
 			wg.Done()
 		}()
 	}

--- a/klayslave/account/contract.go
+++ b/klayslave/account/contract.go
@@ -13,6 +13,7 @@ import (
 	auctionDepositVaultContracts "github.com/kaiachain/kaia-load-tester/klayslave/account/contracts/auctionDepositVault"
 	auctionEntryPointContracts "github.com/kaiachain/kaia-load-tester/klayslave/account/contracts/auctionEntryPoint"
 	auctionFeeVaultContracts "github.com/kaiachain/kaia-load-tester/klayslave/account/contracts/auctionFeeVault"
+	tetherContracts "github.com/kaiachain/kaia-load-tester/klayslave/account/contracts/tetherContract"
 
 	// ----------------
 
@@ -90,6 +91,8 @@ var (
 	UserStorageDeployer           = GetAccountFromKey(0, "c3d4e5f6789012345678901234567890abcdef1234567890abcdef1234567890")
 	InternalTxKIP17Deployer       = GetAccountFromKey(0, "f5a6b7c890123456789012345678901234567890abcdef1234567890abcdef12")
 	InternalTxMainDeployer        = GetAccountFromKey(0, "e4f5a6b7c890123456789012345678901234567890abcdef1234567890abcdef")
+	TetherLogicDeployer           = GetAccountFromKey(0, "a1b2c3d4e5f678901234567890abcdef1234567890abcdef1234567890abcd01")
+	TetherProxyDeployer           = GetAccountFromKey(0, "a1b2c3d4e5f678901234567890abcdef1234567890abcdef1234567890abcd02")
 )
 
 // TestContractInfo represents a test contract configuration
@@ -159,6 +162,8 @@ var TestContractInfos = []TestContractInfo{
 	createUserStorageContractInfo(),
 	createInternalTxKIP17ContractInfo(),
 	createInternalTxMainContractInfo(),
+	createTetherLogicContractInfo(),
+	createTetherProxyContractInfo(),
 }
 
 func createERC20ContractInfo() TestContractInfo {
@@ -661,6 +666,97 @@ func createInternalTxMainContractInfo() TestContractInfo {
 		},
 		IsDeployed: isDeployerNonceNotZero,
 		GetAddress: getNonce0ContractAddress,
+	}
+}
+
+// createTetherLogicContractInfo creates the TetherToken logic contract (implementation)
+// This is deployed first, then the proxy contract points to this address.
+func createTetherLogicContractInfo() TestContractInfo {
+	return TestContractInfo{
+		testNames:                       []string{"erc20TransferWithBlockedListTC"},
+		auctionTargetTxTypeList:         []string{},
+		Bytecode:                        common.FromHex(tetherContracts.TetherContractTCBin),
+		deployer:                        TetherLogicDeployer,
+		contractName:                    "Tether Token Logic Contract",
+		GenData:                         nil,
+		GetBytecodeWithConstructorParam: returnBinAsIs,
+		IsDeployed:                      isDeployerNonceNotZero,
+		GetAddress:                      getNonce0ContractAddress,
+	}
+}
+
+// createTetherProxyContractInfo creates the TransparentUpgradeableProxy contract
+// Constructor params: (address _logic, address admin_, bytes memory _data)
+// _data is the encoded initialize("Tether USD", "USD₮", 6) call
+func createTetherProxyContractInfo() TestContractInfo {
+	return TestContractInfo{
+		testNames:               []string{"erc20TransferWithBlockedListTC"},
+		auctionTargetTxTypeList: []string{},
+		Bytecode:                common.FromHex(tetherContracts.TetherProxyBin),
+		deployer:                TetherProxyDeployer,
+		contractName:            "Tether Token Proxy Contract",
+		GenData: func(recipientAddr common.Address, value *big.Int) []byte {
+			// Use TetherToken ABI for function calls (transfer, balanceOf, etc.)
+			abii, err := abi.JSON(strings.NewReader(tetherContracts.TetherContractTCABI))
+			if err != nil {
+				log.Fatalf("failed to abi.JSON: %v", err)
+			}
+			data, err := abii.Pack("transfer", recipientAddr, value)
+			if err != nil {
+				log.Fatalf("failed to abi.Pack: %v", err)
+			}
+			return data
+		},
+		GetBytecodeWithConstructorParam: func(bin []byte, contracts []*Account, deployer *Account) []byte {
+			// Get the TetherLogic contract address
+			logicAddr := contracts[ContractTetherLogic].address
+			// Use TetherLogicDeployer as proxy admin (not the deployer)
+			// This allows TetherProxyDeployer (the tx sender) to be the TetherToken owner
+			// and still call logic contract functions through the proxy
+			adminAddr := TetherLogicDeployer.address
+
+			// Encode initialize("Tether USD", "USD₮", 6) for _data parameter
+			tetherAbi, err := abi.JSON(strings.NewReader(tetherContracts.TetherContractTCABI))
+			if err != nil {
+				log.Fatalf("failed to parse TetherToken ABI: %v", err)
+			}
+			initData, err := tetherAbi.Pack("initialize", "Tether USD", "USD₮", uint8(6))
+			if err != nil {
+				log.Fatalf("failed to pack initialize data: %v", err)
+			}
+
+			// Pack proxy constructor params: (address _logic, address admin_, bytes memory _data)
+			proxyAbi, err := abi.JSON(strings.NewReader(tetherContracts.TetherProxyABI))
+			if err != nil {
+				log.Fatalf("failed to parse TetherProxy ABI: %v", err)
+			}
+			constructorData, err := proxyAbi.Pack("", logicAddr, adminAddr, initData)
+			if err != nil {
+				log.Fatalf("failed to pack proxy constructor data: %v", err)
+			}
+
+			return append(bin, constructorData...)
+		},
+		IsDeployed: isDeployerNonceNotZero,
+		GetAddress: getNonce0ContractAddress,
+		DoChargingWork: func(ctx *AdditionalWorkContext) {
+			tetherAbi, err := abi.JSON(strings.NewReader(tetherContracts.TetherContractTCABI))
+			if err != nil {
+				log.Fatalf("failed to parse TetherToken ABI: %v", err)
+			}
+
+			// 1. Mint Tether tokens to test accounts
+			log.Printf("Start minting Tether tokens to test accounts")
+			proxyContract := ctx.AccGrp.GetTestContractByName(ContractTetherProxy)
+			ConcurrentTransactionSend(ctx.AccGrp.GetValidAccGrp(), ctx.MaxConcurrency, func(_ int, acc *Account) {
+				data, err := tetherAbi.Pack("mint", acc.address, big.NewInt(1e18))
+				if err != nil {
+					log.Fatalf("failed to pack mint data: %v", err)
+				}
+				TetherProxyDeployer.SmartContractExecutionWithGuaranteeRetry(ctx.GCli, proxyContract, nil, data)
+			})
+			log.Printf("Finished minting Tether tokens")
+		},
 	}
 }
 

--- a/klayslave/account/contracts/go_binding_file_create.sh
+++ b/klayslave/account/contracts/go_binding_file_create.sh
@@ -2,21 +2,21 @@
 
 # Solidity and Go binding file paths and names
 solidity_files=(
-    "cpuHeavy/CPUHeavy.sol"
+    # "cpuHeavy/CPUHeavy.sol"
     #"internalTxTC/InternalTxKIP17Token.sol"
     #"internalTxTC/InternalTxMainContract.sol"
-    "largeMemo/largeMemo.sol"
-    "readApiCallContract/ReadApiCallContract.sol"
-    "UserStorage/UserStorage.sol"
+    # "largeMemo/largeMemo.sol"
+    # "readApiCallContract/ReadApiCallContract.sol"
+    # "UserStorage/UserStorage.sol"
 )
 
 package_names=(
-    "cpuHeavyTC"
+    # "cpuHeavyTC"
     #internalTxTC
     #internalTxTC
-    "largeMemoTC"
-    "readApiCallContractTC"
-    "UserStorageTC"
+    # "largeMemoTC"
+    # "readApiCallContractTC"
+    # "UserStorageTC"
 )
 
 for i in "${!solidity_files[@]}"; do

--- a/klayslave/account/contracts/tetherContract/TetherProxy.go
+++ b/klayslave/account/contracts/tetherContract/TetherProxy.go
@@ -1,0 +1,773 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package tetherContractTC
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	kaia "github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia/accounts/abi"
+	"github.com/kaiachain/kaia/accounts/abi/bind"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = kaia.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// TetherProxyMetaData contains all meta data concerning the TetherProxy contract.
+var TetherProxyMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_logic\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"admin_\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"_data\",\"type\":\"bytes\"}],\"stateMutability\":\"payable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"previousAdmin\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"newAdmin\",\"type\":\"address\"}],\"name\":\"AdminChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"beacon\",\"type\":\"address\"}],\"name\":\"BeaconUpgraded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"implementation\",\"type\":\"address\"}],\"name\":\"Upgraded\",\"type\":\"event\"},{\"stateMutability\":\"payable\",\"type\":\"fallback\"},{\"inputs\":[],\"name\":\"admin\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"admin_\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newAdmin\",\"type\":\"address\"}],\"name\":\"changeAdmin\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"implementation\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"implementation_\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newImplementation\",\"type\":\"address\"}],\"name\":\"upgradeTo\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newImplementation\",\"type\":\"address\"},{\"internalType\":\"bytes\",\"name\":\"data\",\"type\":\"bytes\"}],\"name\":\"upgradeToAndCall\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\"},{\"stateMutability\":\"payable\",\"type\":\"receive\"}]",
+	Bin: "0x6080604052604051610d9e380380610d9e83398101604081905261002291610422565b828161004f60017f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbd6104f3565b5f516020610d575f395f51905f521461006a5761006a610512565b61007582825f6100cf565b506100a3905060017fb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d61046104f3565b5f516020610d375f395f51905f52146100be576100be610512565b6100c7826100fa565b505050610571565b6100d883610167565b5f825111806100e45750805b156100f5576100f383836101a6565b505b505050565b7f7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f6101395f516020610d375f395f51905f52546001600160a01b031690565b604080516001600160a01b03928316815291841660208301520160405180910390a1610164816101d4565b50565b6101708161026f565b6040516001600160a01b038216907fbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b905f90a250565b60606101cb8383604051806060016040528060278152602001610d77602791396102e7565b90505b92915050565b6001600160a01b03811661023e5760405162461bcd60e51b815260206004820152602660248201527f455243313936373a206e65772061646d696e20697320746865207a65726f206160448201526564647265737360d01b60648201526084015b60405180910390fd5b805f516020610d375f395f51905f525b80546001600160a01b0319166001600160a01b039290921691909117905550565b803b6102d35760405162461bcd60e51b815260206004820152602d60248201527f455243313936373a206e657720696d706c656d656e746174696f6e206973206e60448201526c1bdd08184818dbdb9d1c9858dd609a1b6064820152608401610235565b805f516020610d575f395f51905f5261024e565b6060833b6103465760405162461bcd60e51b815260206004820152602660248201527f416464726573733a2064656c65676174652063616c6c20746f206e6f6e2d636f6044820152651b9d1c9858dd60d21b6064820152608401610235565b5f5f856001600160a01b0316856040516103609190610526565b5f60405180830381855af49150503d805f8114610398576040519150601f19603f3d011682016040523d82523d5f602084013e61039d565b606091505b5090925090506103ae8282866103ba565b925050505b9392505050565b606083156103c95750816103b3565b8251156103d95782518084602001fd5b8160405162461bcd60e51b8152600401610235919061053c565b80516001600160a01b0381168114610409575f5ffd5b919050565b634e487b7160e01b5f52604160045260245ffd5b5f5f5f60608486031215610434575f5ffd5b61043d846103f3565b925061044b602085016103f3565b60408501519092506001600160401b03811115610466575f5ffd5b8401601f81018613610476575f5ffd5b80516001600160401b0381111561048f5761048f61040e565b604051601f8201601f19908116603f011681016001600160401b03811182821017156104bd576104bd61040e565b6040528181528282016020018810156104d4575f5ffd5b8160208401602083015e5f602083830101528093505050509250925092565b818103818111156101ce57634e487b7160e01b5f52601160045260245ffd5b634e487b7160e01b5f52600160045260245ffd5b5f82518060208501845e5f920191825250919050565b602081525f82518060208401528060208501604085015e5f604082850101526040601f19601f83011684010191505092915050565b6107b98061057e5f395ff3fe60806040526004361061004d575f3560e01c80633659cfe6146100645780634f1ef286146100835780635c60da1b146100965780638f283970146100c6578063f851a440146100e55761005c565b3661005c5761005a6100f9565b005b61005a6100f9565b34801561006f575f5ffd5b5061005a61007e36600461067a565b610113565b61005a610091366004610693565b61014e565b3480156100a1575f5ffd5b506100aa6101b4565b6040516001600160a01b03909116815260200160405180910390f35b3480156100d1575f5ffd5b5061005a6100e036600461067a565b6101e4565b3480156100f0575f5ffd5b506100aa610204565b610101610224565b61011161010c6102b9565b6102c2565b565b61011b6102e0565b6001600160a01b03163303610146576101438160405180602001604052805f8152505f610312565b50565b6101436100f9565b6101566102e0565b6001600160a01b031633036101ac576101a78383838080601f0160208091040260200160405190810160405280939291908181526020018383808284375f9201919091525060019250610312915050565b505050565b6101a76100f9565b5f6101bd6102e0565b6001600160a01b031633036101d9576101d46102b9565b905090565b6101e16100f9565b90565b6101ec6102e0565b6001600160a01b03163303610146576101438161033c565b5f61020d6102e0565b6001600160a01b031633036101d9576101d46102e0565b61022c6102e0565b6001600160a01b031633036101115760405162461bcd60e51b815260206004820152604260248201527f5472616e73706172656e745570677261646561626c6550726f78793a2061646d60448201527f696e2063616e6e6f742066616c6c6261636b20746f2070726f78792074617267606482015261195d60f21b608482015260a4015b60405180910390fd5b5f6101d4610390565b365f5f375f5f365f845af43d5f5f3e8080156102dc573d5ff35b3d5ffd5b5f7fb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d61035b546001600160a01b0316919050565b61031b836103b7565b5f825111806103275750805b156101a75761033683836103f6565b50505050565b7f7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f6103656102e0565b604080516001600160a01b03928316815291841660208301520160405180910390a161014381610422565b5f7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc610303565b6103c0816104cb565b6040516001600160a01b038216907fbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b905f90a250565b606061041b838360405180606001604052806027815260200161075d60279139610556565b9392505050565b6001600160a01b0381166104875760405162461bcd60e51b815260206004820152602660248201527f455243313936373a206e65772061646d696e20697320746865207a65726f206160448201526564647265737360d01b60648201526084016102b0565b807fb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d61035b80546001600160a01b0319166001600160a01b039290921691909117905550565b803b61052f5760405162461bcd60e51b815260206004820152602d60248201527f455243313936373a206e657720696d706c656d656e746174696f6e206973206e60448201526c1bdd08184818dbdb9d1c9858dd609a1b60648201526084016102b0565b807f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc6104aa565b6060833b6105b55760405162461bcd60e51b815260206004820152602660248201527f416464726573733a2064656c65676174652063616c6c20746f206e6f6e2d636f6044820152651b9d1c9858dd60d21b60648201526084016102b0565b5f5f856001600160a01b0316856040516105cf9190610711565b5f60405180830381855af49150503d805f8114610607576040519150601f19603f3d011682016040523d82523d5f602084013e61060c565b606091505b509150915061061c828286610626565b9695505050505050565b6060831561063557508161041b565b8251156106455782518084602001fd5b8160405162461bcd60e51b81526004016102b09190610727565b80356001600160a01b0381168114610675575f5ffd5b919050565b5f6020828403121561068a575f5ffd5b61041b8261065f565b5f5f5f604084860312156106a5575f5ffd5b6106ae8461065f565b9250602084013567ffffffffffffffff8111156106c9575f5ffd5b8401601f810186136106d9575f5ffd5b803567ffffffffffffffff8111156106ef575f5ffd5b866020828401011115610700575f5ffd5b939660209190910195509293505050565b5f82518060208501845e5f920191825250919050565b602081525f82518060208401528060208501604085015e5f604082850101526040601f19601f8301168401019150509291505056fe416464726573733a206c6f772d6c6576656c2064656c65676174652063616c6c206661696c6564a2646970667358221220502d440fde437e75c6c41f0a27a53d87f511f45629f7ea6a300e1c19b1cda6e164736f6c634300081f0033b53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc416464726573733a206c6f772d6c6576656c2064656c65676174652063616c6c206661696c6564",
+}
+
+// TetherProxyABI is the input ABI used to generate the binding from.
+// Deprecated: Use TetherProxyMetaData.ABI instead.
+var TetherProxyABI = TetherProxyMetaData.ABI
+
+// TetherProxyBin is the compiled bytecode used for deploying new contracts.
+// Deprecated: Use TetherProxyMetaData.Bin instead.
+var TetherProxyBin = TetherProxyMetaData.Bin
+
+// DeployTetherProxy deploys a new Ethereum contract, binding an instance of TetherProxy to it.
+func DeployTetherProxy(auth *bind.TransactOpts, backend bind.ContractBackend, _logic common.Address, admin_ common.Address, _data []byte) (common.Address, *types.Transaction, *TetherProxy, error) {
+	parsed, err := TetherProxyMetaData.GetAbi()
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	if parsed == nil {
+		return common.Address{}, nil, nil, errors.New("GetABI returned nil")
+	}
+
+	address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex(TetherProxyBin), backend, _logic, admin_, _data)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &TetherProxy{TetherProxyCaller: TetherProxyCaller{contract: contract}, TetherProxyTransactor: TetherProxyTransactor{contract: contract}, TetherProxyFilterer: TetherProxyFilterer{contract: contract}}, nil
+}
+
+// TetherProxy is an auto generated Go binding around an Ethereum contract.
+type TetherProxy struct {
+	TetherProxyCaller     // Read-only binding to the contract
+	TetherProxyTransactor // Write-only binding to the contract
+	TetherProxyFilterer   // Log filterer for contract events
+}
+
+// TetherProxyCaller is an auto generated read-only Go binding around an Ethereum contract.
+type TetherProxyCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TetherProxyTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type TetherProxyTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TetherProxyFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type TetherProxyFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TetherProxySession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type TetherProxySession struct {
+	Contract     *TetherProxy      // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// TetherProxyCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type TetherProxyCallerSession struct {
+	Contract *TetherProxyCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts      // Call options to use throughout this session
+}
+
+// TetherProxyTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type TetherProxyTransactorSession struct {
+	Contract     *TetherProxyTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts      // Transaction auth options to use throughout this session
+}
+
+// TetherProxyRaw is an auto generated low-level Go binding around an Ethereum contract.
+type TetherProxyRaw struct {
+	Contract *TetherProxy // Generic contract binding to access the raw methods on
+}
+
+// TetherProxyCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type TetherProxyCallerRaw struct {
+	Contract *TetherProxyCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// TetherProxyTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type TetherProxyTransactorRaw struct {
+	Contract *TetherProxyTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewTetherProxy creates a new instance of TetherProxy, bound to a specific deployed contract.
+func NewTetherProxy(address common.Address, backend bind.ContractBackend) (*TetherProxy, error) {
+	contract, err := bindTetherProxy(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &TetherProxy{TetherProxyCaller: TetherProxyCaller{contract: contract}, TetherProxyTransactor: TetherProxyTransactor{contract: contract}, TetherProxyFilterer: TetherProxyFilterer{contract: contract}}, nil
+}
+
+// NewTetherProxyCaller creates a new read-only instance of TetherProxy, bound to a specific deployed contract.
+func NewTetherProxyCaller(address common.Address, caller bind.ContractCaller) (*TetherProxyCaller, error) {
+	contract, err := bindTetherProxy(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &TetherProxyCaller{contract: contract}, nil
+}
+
+// NewTetherProxyTransactor creates a new write-only instance of TetherProxy, bound to a specific deployed contract.
+func NewTetherProxyTransactor(address common.Address, transactor bind.ContractTransactor) (*TetherProxyTransactor, error) {
+	contract, err := bindTetherProxy(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &TetherProxyTransactor{contract: contract}, nil
+}
+
+// NewTetherProxyFilterer creates a new log filterer instance of TetherProxy, bound to a specific deployed contract.
+func NewTetherProxyFilterer(address common.Address, filterer bind.ContractFilterer) (*TetherProxyFilterer, error) {
+	contract, err := bindTetherProxy(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &TetherProxyFilterer{contract: contract}, nil
+}
+
+// bindTetherProxy binds a generic wrapper to an already deployed contract.
+func bindTetherProxy(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := TetherProxyMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_TetherProxy *TetherProxyRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _TetherProxy.Contract.TetherProxyCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_TetherProxy *TetherProxyRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _TetherProxy.Contract.TetherProxyTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_TetherProxy *TetherProxyRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _TetherProxy.Contract.TetherProxyTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_TetherProxy *TetherProxyCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _TetherProxy.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_TetherProxy *TetherProxyTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _TetherProxy.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_TetherProxy *TetherProxyTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _TetherProxy.Contract.contract.Transact(opts, method, params...)
+}
+
+// Admin is a paid mutator transaction binding the contract method 0xf851a440.
+//
+// Solidity: function admin() returns(address admin_)
+func (_TetherProxy *TetherProxyTransactor) Admin(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _TetherProxy.contract.Transact(opts, "admin")
+}
+
+// Admin is a paid mutator transaction binding the contract method 0xf851a440.
+//
+// Solidity: function admin() returns(address admin_)
+func (_TetherProxy *TetherProxySession) Admin() (*types.Transaction, error) {
+	return _TetherProxy.Contract.Admin(&_TetherProxy.TransactOpts)
+}
+
+// Admin is a paid mutator transaction binding the contract method 0xf851a440.
+//
+// Solidity: function admin() returns(address admin_)
+func (_TetherProxy *TetherProxyTransactorSession) Admin() (*types.Transaction, error) {
+	return _TetherProxy.Contract.Admin(&_TetherProxy.TransactOpts)
+}
+
+// ChangeAdmin is a paid mutator transaction binding the contract method 0x8f283970.
+//
+// Solidity: function changeAdmin(address newAdmin) returns()
+func (_TetherProxy *TetherProxyTransactor) ChangeAdmin(opts *bind.TransactOpts, newAdmin common.Address) (*types.Transaction, error) {
+	return _TetherProxy.contract.Transact(opts, "changeAdmin", newAdmin)
+}
+
+// ChangeAdmin is a paid mutator transaction binding the contract method 0x8f283970.
+//
+// Solidity: function changeAdmin(address newAdmin) returns()
+func (_TetherProxy *TetherProxySession) ChangeAdmin(newAdmin common.Address) (*types.Transaction, error) {
+	return _TetherProxy.Contract.ChangeAdmin(&_TetherProxy.TransactOpts, newAdmin)
+}
+
+// ChangeAdmin is a paid mutator transaction binding the contract method 0x8f283970.
+//
+// Solidity: function changeAdmin(address newAdmin) returns()
+func (_TetherProxy *TetherProxyTransactorSession) ChangeAdmin(newAdmin common.Address) (*types.Transaction, error) {
+	return _TetherProxy.Contract.ChangeAdmin(&_TetherProxy.TransactOpts, newAdmin)
+}
+
+// Implementation is a paid mutator transaction binding the contract method 0x5c60da1b.
+//
+// Solidity: function implementation() returns(address implementation_)
+func (_TetherProxy *TetherProxyTransactor) Implementation(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _TetherProxy.contract.Transact(opts, "implementation")
+}
+
+// Implementation is a paid mutator transaction binding the contract method 0x5c60da1b.
+//
+// Solidity: function implementation() returns(address implementation_)
+func (_TetherProxy *TetherProxySession) Implementation() (*types.Transaction, error) {
+	return _TetherProxy.Contract.Implementation(&_TetherProxy.TransactOpts)
+}
+
+// Implementation is a paid mutator transaction binding the contract method 0x5c60da1b.
+//
+// Solidity: function implementation() returns(address implementation_)
+func (_TetherProxy *TetherProxyTransactorSession) Implementation() (*types.Transaction, error) {
+	return _TetherProxy.Contract.Implementation(&_TetherProxy.TransactOpts)
+}
+
+// UpgradeTo is a paid mutator transaction binding the contract method 0x3659cfe6.
+//
+// Solidity: function upgradeTo(address newImplementation) returns()
+func (_TetherProxy *TetherProxyTransactor) UpgradeTo(opts *bind.TransactOpts, newImplementation common.Address) (*types.Transaction, error) {
+	return _TetherProxy.contract.Transact(opts, "upgradeTo", newImplementation)
+}
+
+// UpgradeTo is a paid mutator transaction binding the contract method 0x3659cfe6.
+//
+// Solidity: function upgradeTo(address newImplementation) returns()
+func (_TetherProxy *TetherProxySession) UpgradeTo(newImplementation common.Address) (*types.Transaction, error) {
+	return _TetherProxy.Contract.UpgradeTo(&_TetherProxy.TransactOpts, newImplementation)
+}
+
+// UpgradeTo is a paid mutator transaction binding the contract method 0x3659cfe6.
+//
+// Solidity: function upgradeTo(address newImplementation) returns()
+func (_TetherProxy *TetherProxyTransactorSession) UpgradeTo(newImplementation common.Address) (*types.Transaction, error) {
+	return _TetherProxy.Contract.UpgradeTo(&_TetherProxy.TransactOpts, newImplementation)
+}
+
+// UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
+//
+// Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
+func (_TetherProxy *TetherProxyTransactor) UpgradeToAndCall(opts *bind.TransactOpts, newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _TetherProxy.contract.Transact(opts, "upgradeToAndCall", newImplementation, data)
+}
+
+// UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
+//
+// Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
+func (_TetherProxy *TetherProxySession) UpgradeToAndCall(newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _TetherProxy.Contract.UpgradeToAndCall(&_TetherProxy.TransactOpts, newImplementation, data)
+}
+
+// UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
+//
+// Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
+func (_TetherProxy *TetherProxyTransactorSession) UpgradeToAndCall(newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _TetherProxy.Contract.UpgradeToAndCall(&_TetherProxy.TransactOpts, newImplementation, data)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() payable returns()
+func (_TetherProxy *TetherProxyTransactor) Fallback(opts *bind.TransactOpts, calldata []byte) (*types.Transaction, error) {
+	return _TetherProxy.contract.RawTransact(opts, calldata)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() payable returns()
+func (_TetherProxy *TetherProxySession) Fallback(calldata []byte) (*types.Transaction, error) {
+	return _TetherProxy.Contract.Fallback(&_TetherProxy.TransactOpts, calldata)
+}
+
+// Fallback is a paid mutator transaction binding the contract fallback function.
+//
+// Solidity: fallback() payable returns()
+func (_TetherProxy *TetherProxyTransactorSession) Fallback(calldata []byte) (*types.Transaction, error) {
+	return _TetherProxy.Contract.Fallback(&_TetherProxy.TransactOpts, calldata)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_TetherProxy *TetherProxyTransactor) Receive(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _TetherProxy.contract.RawTransact(opts, nil) // calldata is disallowed for receive function
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_TetherProxy *TetherProxySession) Receive() (*types.Transaction, error) {
+	return _TetherProxy.Contract.Receive(&_TetherProxy.TransactOpts)
+}
+
+// Receive is a paid mutator transaction binding the contract receive function.
+//
+// Solidity: receive() payable returns()
+func (_TetherProxy *TetherProxyTransactorSession) Receive() (*types.Transaction, error) {
+	return _TetherProxy.Contract.Receive(&_TetherProxy.TransactOpts)
+}
+
+// TetherProxyAdminChangedIterator is returned from FilterAdminChanged and is used to iterate over the raw logs and unpacked data for AdminChanged events raised by the TetherProxy contract.
+type TetherProxyAdminChangedIterator struct {
+	Event *TetherProxyAdminChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  kaia.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TetherProxyAdminChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TetherProxyAdminChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TetherProxyAdminChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TetherProxyAdminChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TetherProxyAdminChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TetherProxyAdminChanged represents a AdminChanged event raised by the TetherProxy contract.
+type TetherProxyAdminChanged struct {
+	PreviousAdmin common.Address
+	NewAdmin      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterAdminChanged is a free log retrieval operation binding the contract event 0x7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f.
+//
+// Solidity: event AdminChanged(address previousAdmin, address newAdmin)
+func (_TetherProxy *TetherProxyFilterer) FilterAdminChanged(opts *bind.FilterOpts) (*TetherProxyAdminChangedIterator, error) {
+
+	logs, sub, err := _TetherProxy.contract.FilterLogs(opts, "AdminChanged")
+	if err != nil {
+		return nil, err
+	}
+	return &TetherProxyAdminChangedIterator{contract: _TetherProxy.contract, event: "AdminChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchAdminChanged is a free log subscription operation binding the contract event 0x7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f.
+//
+// Solidity: event AdminChanged(address previousAdmin, address newAdmin)
+func (_TetherProxy *TetherProxyFilterer) WatchAdminChanged(opts *bind.WatchOpts, sink chan<- *TetherProxyAdminChanged) (event.Subscription, error) {
+
+	logs, sub, err := _TetherProxy.contract.WatchLogs(opts, "AdminChanged")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TetherProxyAdminChanged)
+				if err := _TetherProxy.contract.UnpackLog(event, "AdminChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseAdminChanged is a log parse operation binding the contract event 0x7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f.
+//
+// Solidity: event AdminChanged(address previousAdmin, address newAdmin)
+func (_TetherProxy *TetherProxyFilterer) ParseAdminChanged(log types.Log) (*TetherProxyAdminChanged, error) {
+	event := new(TetherProxyAdminChanged)
+	if err := _TetherProxy.contract.UnpackLog(event, "AdminChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// TetherProxyBeaconUpgradedIterator is returned from FilterBeaconUpgraded and is used to iterate over the raw logs and unpacked data for BeaconUpgraded events raised by the TetherProxy contract.
+type TetherProxyBeaconUpgradedIterator struct {
+	Event *TetherProxyBeaconUpgraded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  kaia.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TetherProxyBeaconUpgradedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TetherProxyBeaconUpgraded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TetherProxyBeaconUpgraded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TetherProxyBeaconUpgradedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TetherProxyBeaconUpgradedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TetherProxyBeaconUpgraded represents a BeaconUpgraded event raised by the TetherProxy contract.
+type TetherProxyBeaconUpgraded struct {
+	Beacon common.Address
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterBeaconUpgraded is a free log retrieval operation binding the contract event 0x1cf3b03a6cf19fa2baba4df148e9dcabedea7f8a5c07840e207e5c089be95d3e.
+//
+// Solidity: event BeaconUpgraded(address indexed beacon)
+func (_TetherProxy *TetherProxyFilterer) FilterBeaconUpgraded(opts *bind.FilterOpts, beacon []common.Address) (*TetherProxyBeaconUpgradedIterator, error) {
+
+	var beaconRule []interface{}
+	for _, beaconItem := range beacon {
+		beaconRule = append(beaconRule, beaconItem)
+	}
+
+	logs, sub, err := _TetherProxy.contract.FilterLogs(opts, "BeaconUpgraded", beaconRule)
+	if err != nil {
+		return nil, err
+	}
+	return &TetherProxyBeaconUpgradedIterator{contract: _TetherProxy.contract, event: "BeaconUpgraded", logs: logs, sub: sub}, nil
+}
+
+// WatchBeaconUpgraded is a free log subscription operation binding the contract event 0x1cf3b03a6cf19fa2baba4df148e9dcabedea7f8a5c07840e207e5c089be95d3e.
+//
+// Solidity: event BeaconUpgraded(address indexed beacon)
+func (_TetherProxy *TetherProxyFilterer) WatchBeaconUpgraded(opts *bind.WatchOpts, sink chan<- *TetherProxyBeaconUpgraded, beacon []common.Address) (event.Subscription, error) {
+
+	var beaconRule []interface{}
+	for _, beaconItem := range beacon {
+		beaconRule = append(beaconRule, beaconItem)
+	}
+
+	logs, sub, err := _TetherProxy.contract.WatchLogs(opts, "BeaconUpgraded", beaconRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TetherProxyBeaconUpgraded)
+				if err := _TetherProxy.contract.UnpackLog(event, "BeaconUpgraded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBeaconUpgraded is a log parse operation binding the contract event 0x1cf3b03a6cf19fa2baba4df148e9dcabedea7f8a5c07840e207e5c089be95d3e.
+//
+// Solidity: event BeaconUpgraded(address indexed beacon)
+func (_TetherProxy *TetherProxyFilterer) ParseBeaconUpgraded(log types.Log) (*TetherProxyBeaconUpgraded, error) {
+	event := new(TetherProxyBeaconUpgraded)
+	if err := _TetherProxy.contract.UnpackLog(event, "BeaconUpgraded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// TetherProxyUpgradedIterator is returned from FilterUpgraded and is used to iterate over the raw logs and unpacked data for Upgraded events raised by the TetherProxy contract.
+type TetherProxyUpgradedIterator struct {
+	Event *TetherProxyUpgraded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  kaia.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TetherProxyUpgradedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TetherProxyUpgraded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TetherProxyUpgraded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TetherProxyUpgradedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TetherProxyUpgradedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TetherProxyUpgraded represents a Upgraded event raised by the TetherProxy contract.
+type TetherProxyUpgraded struct {
+	Implementation common.Address
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterUpgraded is a free log retrieval operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_TetherProxy *TetherProxyFilterer) FilterUpgraded(opts *bind.FilterOpts, implementation []common.Address) (*TetherProxyUpgradedIterator, error) {
+
+	var implementationRule []interface{}
+	for _, implementationItem := range implementation {
+		implementationRule = append(implementationRule, implementationItem)
+	}
+
+	logs, sub, err := _TetherProxy.contract.FilterLogs(opts, "Upgraded", implementationRule)
+	if err != nil {
+		return nil, err
+	}
+	return &TetherProxyUpgradedIterator{contract: _TetherProxy.contract, event: "Upgraded", logs: logs, sub: sub}, nil
+}
+
+// WatchUpgraded is a free log subscription operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_TetherProxy *TetherProxyFilterer) WatchUpgraded(opts *bind.WatchOpts, sink chan<- *TetherProxyUpgraded, implementation []common.Address) (event.Subscription, error) {
+
+	var implementationRule []interface{}
+	for _, implementationItem := range implementation {
+		implementationRule = append(implementationRule, implementationItem)
+	}
+
+	logs, sub, err := _TetherProxy.contract.WatchLogs(opts, "Upgraded", implementationRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TetherProxyUpgraded)
+				if err := _TetherProxy.contract.UnpackLog(event, "Upgraded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUpgraded is a log parse operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_TetherProxy *TetherProxyFilterer) ParseUpgraded(log types.Log) (*TetherProxyUpgraded, error) {
+	event := new(TetherProxyUpgraded)
+	if err := _TetherProxy.contract.UnpackLog(event, "Upgraded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/klayslave/account/contracts/tetherContract/TransparentUpgradeableProxyFlattened.sol
+++ b/klayslave/account/contracts/tetherContract/TransparentUpgradeableProxyFlattened.sol
@@ -1,0 +1,741 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+// node_modules/@openzeppelin/contracts/utils/Address.sol
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [IMPORTANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies on extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        assembly {
+            size := extcodesize(account)
+        }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * IMPORTANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        (bool success, ) = recipient.call{value: amount}("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain `call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+        return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(
+        address target,
+        bytes memory data,
+        string memory errorMessage
+    ) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(
+        address target,
+        bytes memory data,
+        uint256 value
+    ) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(
+        address target,
+        bytes memory data,
+        uint256 value,
+        string memory errorMessage
+    ) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        require(isContract(target), "Address: call to non-contract");
+
+        (bool success, bytes memory returndata) = target.call{value: value}(data);
+        return _verifyCallResult(success, returndata, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but performing a static call.
+     *
+     * _Available since v3.3._
+     */
+    function functionStaticCall(address target, bytes memory data) internal view returns (bytes memory) {
+        return functionStaticCall(target, data, "Address: low-level static call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
+     * but performing a static call.
+     *
+     * _Available since v3.3._
+     */
+    function functionStaticCall(
+        address target,
+        bytes memory data,
+        string memory errorMessage
+    ) internal view returns (bytes memory) {
+        require(isContract(target), "Address: static call to non-contract");
+
+        (bool success, bytes memory returndata) = target.staticcall(data);
+        return _verifyCallResult(success, returndata, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but performing a delegate call.
+     *
+     * _Available since v3.4._
+     */
+    function functionDelegateCall(address target, bytes memory data) internal returns (bytes memory) {
+        return functionDelegateCall(target, data, "Address: low-level delegate call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
+     * but performing a delegate call.
+     *
+     * _Available since v3.4._
+     */
+    function functionDelegateCall(
+        address target,
+        bytes memory data,
+        string memory errorMessage
+    ) internal returns (bytes memory) {
+        require(isContract(target), "Address: delegate call to non-contract");
+
+        (bool success, bytes memory returndata) = target.delegatecall(data);
+        return _verifyCallResult(success, returndata, errorMessage);
+    }
+
+    function _verifyCallResult(
+        bool success,
+        bytes memory returndata,
+        string memory errorMessage
+    ) private pure returns (bytes memory) {
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}
+
+// node_modules/@openzeppelin/contracts/proxy/beacon/IBeacon.sol
+
+/**
+ * @dev This is the interface that {BeaconProxy} expects of its beacon.
+ */
+interface IBeacon {
+    /**
+     * @dev Must return an address that can be used as a delegate call target.
+     *
+     * {BeaconProxy} will check that this address is a contract.
+     */
+    function implementation() external view returns (address);
+}
+
+// node_modules/@openzeppelin/contracts/proxy/Proxy.sol
+
+/**
+ * @dev This abstract contract provides a fallback function that delegates all calls to another contract using the EVM
+ * instruction `delegatecall`. We refer to the second contract as the _implementation_ behind the proxy, and it has to
+ * be specified by overriding the virtual {_implementation} function.
+ *
+ * Additionally, delegation to the implementation can be triggered manually through the {_fallback} function, or to a
+ * different contract through the {_delegate} function.
+ *
+ * The success and return data of the delegated call will be returned back to the caller of the proxy.
+ */
+abstract contract Proxy {
+    /**
+     * @dev Delegates the current call to `implementation`.
+     *
+     * This function does not return to its internall call site, it will return directly to the external caller.
+     */
+    function _delegate(address implementation) internal virtual {
+        assembly {
+            // Copy msg.data. We take full control of memory in this inline assembly
+            // block because it will not return to Solidity code. We overwrite the
+            // Solidity scratch pad at memory position 0.
+            calldatacopy(0, 0, calldatasize())
+
+            // Call the implementation.
+            // out and outsize are 0 because we don't know the size yet.
+            let result := delegatecall(gas(), implementation, 0, calldatasize(), 0, 0)
+
+            // Copy the returned data.
+            returndatacopy(0, 0, returndatasize())
+
+            switch result
+            // delegatecall returns 0 on error.
+            case 0 {
+                revert(0, returndatasize())
+            }
+            default {
+                return(0, returndatasize())
+            }
+        }
+    }
+
+    /**
+     * @dev This is a virtual function that should be overriden so it returns the address to which the fallback function
+     * and {_fallback} should delegate.
+     */
+    function _implementation() internal view virtual returns (address);
+
+    /**
+     * @dev Delegates the current call to the address returned by `_implementation()`.
+     *
+     * This function does not return to its internall call site, it will return directly to the external caller.
+     */
+    function _fallback() internal virtual {
+        _beforeFallback();
+        _delegate(_implementation());
+    }
+
+    /**
+     * @dev Fallback function that delegates calls to the address returned by `_implementation()`. Will run if no other
+     * function in the contract matches the call data.
+     */
+    fallback() external payable virtual {
+        _fallback();
+    }
+
+    /**
+     * @dev Fallback function that delegates calls to the address returned by `_implementation()`. Will run if call data
+     * is empty.
+     */
+    receive() external payable virtual {
+        _fallback();
+    }
+
+    /**
+     * @dev Hook that is called before falling back to the implementation. Can happen as part of a manual `_fallback`
+     * call, or as part of the Solidity `fallback` or `receive` functions.
+     *
+     * If overriden should call `super._beforeFallback()`.
+     */
+    function _beforeFallback() internal virtual {}
+}
+
+// node_modules/@openzeppelin/contracts/utils/StorageSlot.sol
+
+/**
+ * @dev Library for reading and writing primitive types to specific storage slots.
+ *
+ * Storage slots are often used to avoid storage conflict when dealing with upgradeable contracts.
+ * This library helps with reading and writing to such slots without the need for inline assembly.
+ *
+ * The functions in this library return Slot structs that contain a `value` member that can be used to read or write.
+ *
+ * Example usage to set ERC1967 implementation slot:
+ * ```
+ * contract ERC1967 {
+ *     bytes32 internal constant _IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+ *
+ *     function _getImplementation() internal view returns (address) {
+ *         return StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value;
+ *     }
+ *
+ *     function _setImplementation(address newImplementation) internal {
+ *         require(Address.isContract(newImplementation), "ERC1967: new implementation is not a contract");
+ *         StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value = newImplementation;
+ *     }
+ * }
+ * ```
+ *
+ * _Available since v4.1 for `address`, `bool`, `bytes32`, and `uint256`._
+ */
+library StorageSlot {
+    struct AddressSlot {
+        address value;
+    }
+
+    struct BooleanSlot {
+        bool value;
+    }
+
+    struct Bytes32Slot {
+        bytes32 value;
+    }
+
+    struct Uint256Slot {
+        uint256 value;
+    }
+
+    /**
+     * @dev Returns an `AddressSlot` with member `value` located at `slot`.
+     */
+    function getAddressSlot(bytes32 slot) internal pure returns (AddressSlot storage r) {
+        assembly {
+            r.slot := slot
+        }
+    }
+
+    /**
+     * @dev Returns an `BooleanSlot` with member `value` located at `slot`.
+     */
+    function getBooleanSlot(bytes32 slot) internal pure returns (BooleanSlot storage r) {
+        assembly {
+            r.slot := slot
+        }
+    }
+
+    /**
+     * @dev Returns an `Bytes32Slot` with member `value` located at `slot`.
+     */
+    function getBytes32Slot(bytes32 slot) internal pure returns (Bytes32Slot storage r) {
+        assembly {
+            r.slot := slot
+        }
+    }
+
+    /**
+     * @dev Returns an `Uint256Slot` with member `value` located at `slot`.
+     */
+    function getUint256Slot(bytes32 slot) internal pure returns (Uint256Slot storage r) {
+        assembly {
+            r.slot := slot
+        }
+    }
+}
+
+// node_modules/@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol
+
+/**
+ * @dev This abstract contract provides getters and event emitting update functions for
+ * https://eips.ethereum.org/EIPS/eip-1967[EIP1967] slots.
+ *
+ * _Available since v4.1._
+ *
+ * @custom:oz-upgrades-unsafe-allow delegatecall
+ */
+abstract contract ERC1967Upgrade {
+    // This is the keccak-256 hash of "eip1967.proxy.rollback" subtracted by 1
+    bytes32 private constant _ROLLBACK_SLOT = 0x4910fdfa16fed3260ed0e7147f7cc6da11a60208b5b9406d12a635614ffd9143;
+
+    /**
+     * @dev Storage slot with the address of the current implementation.
+     * This is the keccak-256 hash of "eip1967.proxy.implementation" subtracted by 1, and is
+     * validated in the constructor.
+     */
+    bytes32 internal constant _IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+    /**
+     * @dev Emitted when the implementation is upgraded.
+     */
+    event Upgraded(address indexed implementation);
+
+    /**
+     * @dev Returns the current implementation address.
+     */
+    function _getImplementation() internal view returns (address) {
+        return StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value;
+    }
+
+    /**
+     * @dev Stores a new address in the EIP1967 implementation slot.
+     */
+    function _setImplementation(address newImplementation) private {
+        require(Address.isContract(newImplementation), "ERC1967: new implementation is not a contract");
+        StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value = newImplementation;
+    }
+
+    /**
+     * @dev Perform implementation upgrade
+     *
+     * Emits an {Upgraded} event.
+     */
+    function _upgradeTo(address newImplementation) internal {
+        _setImplementation(newImplementation);
+        emit Upgraded(newImplementation);
+    }
+
+    /**
+     * @dev Perform implementation upgrade with additional setup call.
+     *
+     * Emits an {Upgraded} event.
+     */
+    function _upgradeToAndCall(
+        address newImplementation,
+        bytes memory data,
+        bool forceCall
+    ) internal {
+        _upgradeTo(newImplementation);
+        if (data.length > 0 || forceCall) {
+            Address.functionDelegateCall(newImplementation, data);
+        }
+    }
+
+    /**
+     * @dev Perform implementation upgrade with security checks for UUPS proxies, and additional setup call.
+     *
+     * Emits an {Upgraded} event.
+     */
+    function _upgradeToAndCallSecure(
+        address newImplementation,
+        bytes memory data,
+        bool forceCall
+    ) internal {
+        address oldImplementation = _getImplementation();
+
+        // Initial upgrade and setup call
+        _setImplementation(newImplementation);
+        if (data.length > 0 || forceCall) {
+            Address.functionDelegateCall(newImplementation, data);
+        }
+
+        // Perform rollback test if not already in progress
+        StorageSlot.BooleanSlot storage rollbackTesting = StorageSlot.getBooleanSlot(_ROLLBACK_SLOT);
+        if (!rollbackTesting.value) {
+            // Trigger rollback using upgradeTo from the new implementation
+            rollbackTesting.value = true;
+            Address.functionDelegateCall(
+                newImplementation,
+                abi.encodeWithSignature("upgradeTo(address)", oldImplementation)
+            );
+            rollbackTesting.value = false;
+            // Check rollback was effective
+            require(oldImplementation == _getImplementation(), "ERC1967Upgrade: upgrade breaks further upgrades");
+            // Finally reset to the new implementation and log the upgrade
+            _upgradeTo(newImplementation);
+        }
+    }
+
+    /**
+     * @dev Storage slot with the admin of the contract.
+     * This is the keccak-256 hash of "eip1967.proxy.admin" subtracted by 1, and is
+     * validated in the constructor.
+     */
+    bytes32 internal constant _ADMIN_SLOT = 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
+
+    /**
+     * @dev Emitted when the admin account has changed.
+     */
+    event AdminChanged(address previousAdmin, address newAdmin);
+
+    /**
+     * @dev Returns the current admin.
+     */
+    function _getAdmin() internal view returns (address) {
+        return StorageSlot.getAddressSlot(_ADMIN_SLOT).value;
+    }
+
+    /**
+     * @dev Stores a new address in the EIP1967 admin slot.
+     */
+    function _setAdmin(address newAdmin) private {
+        require(newAdmin != address(0), "ERC1967: new admin is the zero address");
+        StorageSlot.getAddressSlot(_ADMIN_SLOT).value = newAdmin;
+    }
+
+    /**
+     * @dev Changes the admin of the proxy.
+     *
+     * Emits an {AdminChanged} event.
+     */
+    function _changeAdmin(address newAdmin) internal {
+        emit AdminChanged(_getAdmin(), newAdmin);
+        _setAdmin(newAdmin);
+    }
+
+    /**
+     * @dev The storage slot of the UpgradeableBeacon contract which defines the implementation for this proxy.
+     * This is bytes32(uint256(keccak256('eip1967.proxy.beacon')) - 1)) and is validated in the constructor.
+     */
+    bytes32 internal constant _BEACON_SLOT = 0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50;
+
+    /**
+     * @dev Emitted when the beacon is upgraded.
+     */
+    event BeaconUpgraded(address indexed beacon);
+
+    /**
+     * @dev Returns the current beacon.
+     */
+    function _getBeacon() internal view returns (address) {
+        return StorageSlot.getAddressSlot(_BEACON_SLOT).value;
+    }
+
+    /**
+     * @dev Stores a new beacon in the EIP1967 beacon slot.
+     */
+    function _setBeacon(address newBeacon) private {
+        require(Address.isContract(newBeacon), "ERC1967: new beacon is not a contract");
+        require(
+            Address.isContract(IBeacon(newBeacon).implementation()),
+            "ERC1967: beacon implementation is not a contract"
+        );
+        StorageSlot.getAddressSlot(_BEACON_SLOT).value = newBeacon;
+    }
+
+    /**
+     * @dev Perform beacon upgrade with additional setup call. Note: This upgrades the address of the beacon, it does
+     * not upgrade the implementation contained in the beacon (see {UpgradeableBeacon-_setImplementation} for that).
+     *
+     * Emits a {BeaconUpgraded} event.
+     */
+    function _upgradeBeaconToAndCall(
+        address newBeacon,
+        bytes memory data,
+        bool forceCall
+    ) internal {
+        _setBeacon(newBeacon);
+        emit BeaconUpgraded(newBeacon);
+        if (data.length > 0 || forceCall) {
+            Address.functionDelegateCall(IBeacon(newBeacon).implementation(), data);
+        }
+    }
+}
+
+// node_modules/@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol
+
+/**
+ * @dev This contract implements an upgradeable proxy. It is upgradeable because calls are delegated to an
+ * implementation address that can be changed. This address is stored in storage in the location specified by
+ * https://eips.ethereum.org/EIPS/eip-1967[EIP1967], so that it doesn't conflict with the storage layout of the
+ * implementation behind the proxy.
+ */
+contract ERC1967Proxy is Proxy, ERC1967Upgrade {
+    /**
+     * @dev Initializes the upgradeable proxy with an initial implementation specified by `_logic`.
+     *
+     * If `_data` is nonempty, it's used as data in a delegate call to `_logic`. This will typically be an encoded
+     * function call, and allows initializating the storage of the proxy like a Solidity constructor.
+     */
+    constructor(address _logic, bytes memory _data) payable {
+        assert(_IMPLEMENTATION_SLOT == bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1));
+        _upgradeToAndCall(_logic, _data, false);
+    }
+
+    /**
+     * @dev Returns the current implementation address.
+     */
+    function _implementation() internal view virtual override returns (address impl) {
+        return ERC1967Upgrade._getImplementation();
+    }
+}
+
+// node_modules/@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol
+
+/**
+ * @dev This contract implements a proxy that is upgradeable by an admin.
+ *
+ * To avoid https://medium.com/nomic-labs-blog/malicious-backdoors-in-ethereum-proxies-62629adf3357[proxy selector
+ * clashing], which can potentially be used in an attack, this contract uses the
+ * https://blog.openzeppelin.com/the-transparent-proxy-pattern/[transparent proxy pattern]. This pattern implies two
+ * things that go hand in hand:
+ *
+ * 1. If any account other than the admin calls the proxy, the call will be forwarded to the implementation, even if
+ * that call matches one of the admin functions exposed by the proxy itself.
+ * 2. If the admin calls the proxy, it can access the admin functions, but its calls will never be forwarded to the
+ * implementation. If the admin tries to call a function on the implementation it will fail with an error that says
+ * "admin cannot fallback to proxy target".
+ *
+ * These properties mean that the admin account can only be used for admin actions like upgrading the proxy or changing
+ * the admin, so it's best if it's a dedicated account that is not used for anything else. This will avoid headaches due
+ * to sudden errors when trying to call a function from the proxy implementation.
+ *
+ * Our recommendation is for the dedicated account to be an instance of the {ProxyAdmin} contract. If set up this way,
+ * you should think of the `ProxyAdmin` instance as the real administrative interface of your proxy.
+ */
+contract TransparentUpgradeableProxy is ERC1967Proxy {
+    /**
+     * @dev Initializes an upgradeable proxy managed by `_admin`, backed by the implementation at `_logic`, and
+     * optionally initialized with `_data` as explained in {ERC1967Proxy-constructor}.
+     */
+    constructor(
+        address _logic,
+        address admin_,
+        bytes memory _data
+    ) payable ERC1967Proxy(_logic, _data) {
+        assert(
+            _ADMIN_SLOT ==
+                bytes32(uint256(keccak256("eip1967.proxy.admin")) - 1)
+        );
+        _changeAdmin(admin_);
+    }
+
+    /**
+     * @dev Modifier used internally that will delegate the call to the implementation unless the sender is the admin.
+     */
+    modifier ifAdmin() {
+        if (msg.sender == _getAdmin()) {
+            _;
+        } else {
+            _fallback();
+        }
+    }
+
+    /**
+     * @dev Returns the current admin.
+     *
+     * NOTE: Only the admin can call this function. See {ProxyAdmin-getProxyAdmin}.
+     *
+     * TIP: To get this value clients can read directly from the storage slot shown below (specified by EIP1967) using the
+     * https://eth.wiki/json-rpc/API#eth_getstorageat[`eth_getStorageAt`] RPC call.
+     * `0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103`
+     */
+    function admin() external ifAdmin returns (address admin_) {
+        admin_ = _getAdmin();
+    }
+
+    /**
+     * @dev Returns the current implementation.
+     *
+     * NOTE: Only the admin can call this function. See {ProxyAdmin-getProxyImplementation}.
+     *
+     * TIP: To get this value clients can read directly from the storage slot shown below (specified by EIP1967) using the
+     * https://eth.wiki/json-rpc/API#eth_getstorageat[`eth_getStorageAt`] RPC call.
+     * `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc`
+     */
+    function implementation()
+        external
+        ifAdmin
+        returns (address implementation_)
+    {
+        implementation_ = _implementation();
+    }
+
+    /**
+     * @dev Changes the admin of the proxy.
+     *
+     * Emits an {AdminChanged} event.
+     *
+     * NOTE: Only the admin can call this function. See {ProxyAdmin-changeProxyAdmin}.
+     */
+    function changeAdmin(address newAdmin) external virtual ifAdmin {
+        _changeAdmin(newAdmin);
+    }
+
+    /**
+     * @dev Upgrade the implementation of the proxy.
+     *
+     * NOTE: Only the admin can call this function. See {ProxyAdmin-upgrade}.
+     */
+    function upgradeTo(address newImplementation) external ifAdmin {
+        _upgradeToAndCall(newImplementation, bytes(""), false);
+    }
+
+    /**
+     * @dev Upgrade the implementation of the proxy, and then call a function from the new implementation as specified
+     * by `data`, which should be an encoded function call. This is useful to initialize new storage variables in the
+     * proxied contract.
+     *
+     * NOTE: Only the admin can call this function. See {ProxyAdmin-upgradeAndCall}.
+     */
+    function upgradeToAndCall(
+        address newImplementation,
+        bytes calldata data
+    ) external payable ifAdmin {
+        _upgradeToAndCall(newImplementation, data, true);
+    }
+
+    /**
+     * @dev Returns the current admin.
+     */
+    function _admin() internal view virtual returns (address) {
+        return _getAdmin();
+    }
+
+    /**
+     * @dev Makes sure the admin cannot access the fallback function. See {Proxy-_beforeFallback}.
+     */
+    function _beforeFallback() internal virtual override {
+        require(
+            msg.sender != _getAdmin(),
+            "TransparentUpgradeableProxy: admin cannot fallback to proxy target"
+        );
+        super._beforeFallback();
+    }
+}

--- a/klayslave/account/contracts/tetherContract/WithBlockedList.sol
+++ b/klayslave/account/contracts/tetherContract/WithBlockedList.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache 2.0
+
+pragma solidity ^0.8.4;
+
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+
+/*
+
+   Copyright Tether.to 2020
+
+   Author Will Harborne
+
+   Licensed under the Apache License, Version 2.0
+   http://www.apache.org/licenses/LICENSE-2.0
+
+*/
+
+
+contract WithBlockedList is OwnableUpgradeable {
+
+    /**
+     * @dev Reverts if called by a blocked account
+     */
+    modifier onlyNotBlocked() {
+      require(!isBlocked[_msgSender()], "Blocked: msg.sender is blocked");
+      _;
+    }
+
+    mapping (address => bool) public isBlocked;
+
+    function addToBlockedList (address _user) public onlyOwner {
+        isBlocked[_user] = true;
+        emit BlockPlaced(_user);
+    }
+
+    function removeFromBlockedList (address _user) public onlyOwner {
+        isBlocked[_user] = false;
+        emit BlockReleased(_user);
+    }
+
+    event BlockPlaced(address indexed _user);
+
+    event BlockReleased(address indexed _user);
+    
+}

--- a/klayslave/account/contracts/tetherContract/tetherToken.go
+++ b/klayslave/account/contracts/tetherContract/tetherToken.go
@@ -1,0 +1,2166 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package tetherContractTC
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	"github.com/kaiachain/kaia"
+	"github.com/kaiachain/kaia/accounts/abi"
+	"github.com/kaiachain/kaia/accounts/abi/bind"
+	"github.com/kaiachain/kaia/common"
+	"github.com/kaiachain/kaia/blockchain/types"
+	"github.com/kaiachain/kaia/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = kaia.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// TetherContractTCMetaData contains all meta data concerning the TetherContractTC contract.
+var TetherContractTCMetaData = &bind.MetaData{
+	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Approval\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"_user\",\"type\":\"address\"}],\"name\":\"BlockPlaced\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"_user\",\"type\":\"address\"}],\"name\":\"BlockReleased\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"_blockedUser\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"_balance\",\"type\":\"uint256\"}],\"name\":\"DestroyedBlockedFunds\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"version\",\"type\":\"uint8\"}],\"name\":\"Initialized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"_destination\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"_amount\",\"type\":\"uint256\"}],\"name\":\"Mint\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"_amount\",\"type\":\"uint256\"}],\"name\":\"Redeem\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"Transfer\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"DOMAIN_SEPARATOR\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_user\",\"type\":\"address\"}],\"name\":\"addToBlockedList\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"}],\"name\":\"allowance\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"approve\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"balanceOf\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"decimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"subtractedValue\",\"type\":\"uint256\"}],\"name\":\"decreaseAllowance\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_blockedUser\",\"type\":\"address\"}],\"name\":\"destroyBlockedFunds\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"addedValue\",\"type\":\"uint256\"}],\"name\":\"increaseAllowance\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"_name\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"_symbol\",\"type\":\"string\"},{\"internalType\":\"uint8\",\"name\":\"_decimals\",\"type\":\"uint8\"}],\"name\":\"initialize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"isBlocked\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"isTrusted\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_destination\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_amount\",\"type\":\"uint256\"}],\"name\":\"mint\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address[]\",\"name\":\"_recipients\",\"type\":\"address[]\"},{\"internalType\":\"uint256[]\",\"name\":\"_values\",\"type\":\"uint256[]\"}],\"name\":\"multiTransfer\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"name\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"}],\"name\":\"nonces\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"owner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"spender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"deadline\",\"type\":\"uint256\"},{\"internalType\":\"uint8\",\"name\":\"v\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"r\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"s\",\"type\":\"bytes32\"}],\"name\":\"permit\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_amount\",\"type\":\"uint256\"}],\"name\":\"redeem\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_user\",\"type\":\"address\"}],\"name\":\"removeFromBlockedList\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"renounceOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"symbol\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"totalSupply\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"transfer\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_sender\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_recipient\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_amount\",\"type\":\"uint256\"}],\"name\":\"transferFrom\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+	Bin: "0x6080604052348015600e575f5ffd5b50611ca38061001c5f395ff3fe608060405234801561000f575f5ffd5b5060043610610187575f3560e01c806370a08231116100d9578063a457c2d711610093578063db006a751161006e578063db006a7514610358578063dd62ed3e1461036b578063f2fde38b1461037e578063fbac395114610391575f5ffd5b8063a457c2d71461031f578063a9059cbb14610332578063d505accf14610345575f5ffd5b806370a0823114610296578063715018a6146102be5780637ecebe00146102c65780638da5cb5b146102d957806395d89b41146102f457806396d64879146102fc575f5ffd5b80631e89d545116101445780633644e5151161011f5780633644e51514610255578063395093511461025d5780633c7c9b901461027057806340c10f1914610283575f5ffd5b80631e89d5451461021957806323b872dd1461022c578063313ce5671461023f575f5ffd5b806306fdde031461018b578063095ea7b3146101a95780630e27a385146101cc5780631624f6c6146101e157806318160ddd146101f45780631a14f44914610206575b5f5ffd5b6101936103b3565b6040516101a09190611753565b60405180910390f35b6101bc6101b73660046117a3565b610443565b60405190151581526020016101a0565b6101df6101da3660046117cb565b61045c565b005b6101df6101ef36600461189a565b610539565b6035545b6040519081526020016101a0565b6101df6102143660046117cb565b61066a565b6101df610227366004611956565b6106ba565b6101bc61023a3660046119c2565b610777565b6101005460405160ff90911681526020016101a0565b6101f86107e9565b6101bc61026b3660046117a3565b6107f7565b6101df61027e3660046117cb565b610818565b6101df6102913660046117a3565b61086b565b6101f86102a43660046117cb565b6001600160a01b03165f9081526033602052604090205490565b6101df6108b8565b6101f86102d43660046117cb565b6108cb565b60cc546040516001600160a01b0390911681526020016101a0565b6101936108e8565b6101bc61030a3660046117cb565b60ff60208190525f9182526040909120541681565b6101bc61032d3660046117a3565b6108f7565b6101bc6103403660046117a3565b61097c565b6101df6103533660046119fc565b610989565b6101df610366366004611a62565b610aea565b6101f8610379366004611a79565b610b43565b6101df61038c3660046117cb565b610b6d565b6101bc61039f3660046117cb565b60fe6020525f908152604090205460ff1681565b6060603680546103c290611aaa565b80601f01602080910402602001604051908101604052809291908181526020018280546103ee90611aaa565b80156104395780601f1061041057610100808354040283529160200191610439565b820191905f5260205f20905b81548152906001019060200180831161041c57829003601f168201915b5050505050905090565b5f33610450818585610be6565b60019150505b92915050565b610464610d0a565b6001600160a01b0381165f90815260fe602052604090205460ff166104d05760405162461bcd60e51b815260206004820181905260248201527f546574686572546f6b656e3a2075736572206973206e6f7420626c6f636b656460448201526064015b60405180910390fd5b6001600160a01b0381165f908152603360205260409020546104f28282610d64565b816001600160a01b03167f6a2859ae7902313752498feb80a014e6e7275fe964c79aa965db815db1c7f1e98260405161052d91815260200190565b60405180910390a25050565b5f54610100900460ff161580801561055757505f54600160ff909116105b806105705750303b15801561057057505f5460ff166001145b6105d35760405162461bcd60e51b815260206004820152602e60248201527f496e697469616c697a61626c653a20636f6e747261637420697320616c72656160448201526d191e481a5b9a5d1a585b1a5e995960921b60648201526084016104c7565b5f805460ff1916600117905580156105f4575f805461ff0019166101001790555b610100805460ff191660ff841617905561060c610e9e565b6106168484610ecc565b61061f84610f00565b8015610664575f805461ff0019169055604051600181527f7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb38474024989060200160405180910390a15b50505050565b610672610d0a565b6001600160a01b0381165f81815260fe6020526040808220805460ff19169055517f665918c9e02eb2fd85acca3969cb054fc84c138e60ec4af22ab6ef2fd4c93c279190a250565b8281146107155760405162461bcd60e51b815260206004820152602360248201527f546574686572546f6b656e3a206d756c74695472616e73666572206d69736d616044820152620e8c6d60eb1b60648201526084016104c7565b5f5b838110156107705761076785858381811061073457610734611adc565b905060200201602081019061074991906117cb565b84848481811061075b5761075b611adc565b9050602002013561097c565b50600101610717565b5050505050565b335f90815260fe602052604081205460ff16156107d65760405162461bcd60e51b815260206004820152601e60248201527f426c6f636b65643a206d73672e73656e64657220697320626c6f636b6564000060448201526064016104c7565b6107e1848484610f49565b949350505050565b5f6107f2610f61565b905090565b5f336104508185856108098383610b43565b6108139190611af0565b610be6565b610820610d0a565b6001600160a01b0381165f81815260fe6020526040808220805460ff19166001179055517f406bbf2d8d145125adf1198d2cf8a67c66cc4bb0ab01c37dccd4f7c0aae1e7c79190a250565b610873610d0a565b61087d8282610fda565b816001600160a01b03167f0f6798a560793a54c3bcfe86a93cde1e73087d944c0ea20544137d41213968858260405161052d91815260200190565b6108c0610d0a565b6108c95f6110a4565b565b6001600160a01b0381165f90815260996020526040812054610456565b6060603780546103c290611aaa565b5f33816109048286610b43565b9050838110156109645760405162461bcd60e51b815260206004820152602560248201527f45524332303a2064656372656173656420616c6c6f77616e63652062656c6f77604482015264207a65726f60d81b60648201526084016104c7565b6109718286868403610be6565b506001949350505050565b5f336104508185856110f5565b834211156109d95760405162461bcd60e51b815260206004820152601d60248201527f45524332305065726d69743a206578706972656420646561646c696e6500000060448201526064016104c7565b5f7f6e71edae12b1b97f4d1f60370fef10105fa2faae0126114a169c64845d6126c9888888610a078c6112a9565b6040805160208101969096526001600160a01b0394851690860152929091166060840152608083015260a082015260c0810186905260e0016040516020818303038152906040528051906020012090505f610a61826112d0565b90505f610a708287878761131c565b9050896001600160a01b0316816001600160a01b031614610ad35760405162461bcd60e51b815260206004820152601e60248201527f45524332305065726d69743a20696e76616c6964207369676e6174757265000060448201526064016104c7565b610ade8a8a8a610be6565b50505050505050505050565b610af2610d0a565b610b0d610b0760cc546001600160a01b031690565b82610d64565b6040518181527f702d5967f45f6513a38ffc42d6ba9bf230bd40e8f53b16363c7eb4fd2deb9a449060200160405180910390a150565b6001600160a01b039182165f90815260346020908152604080832093909416825291909152205490565b610b75610d0a565b6001600160a01b038116610bda5760405162461bcd60e51b815260206004820152602660248201527f4f776e61626c653a206e6577206f776e657220697320746865207a65726f206160448201526564647265737360d01b60648201526084016104c7565b610be3816110a4565b50565b6001600160a01b038316610c485760405162461bcd60e51b8152602060048201526024808201527f45524332303a20617070726f76652066726f6d20746865207a65726f206164646044820152637265737360e01b60648201526084016104c7565b6001600160a01b038216610ca95760405162461bcd60e51b815260206004820152602260248201527f45524332303a20617070726f766520746f20746865207a65726f206164647265604482015261737360f01b60648201526084016104c7565b6001600160a01b038381165f8181526034602090815260408083209487168084529482529182902085905590518481527f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b92591015b60405180910390a3505050565b60cc546001600160a01b031633146108c95760405162461bcd60e51b815260206004820181905260248201527f4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e657260448201526064016104c7565b6001600160a01b038216610dc45760405162461bcd60e51b815260206004820152602160248201527f45524332303a206275726e2066726f6d20746865207a65726f206164647265736044820152607360f81b60648201526084016104c7565b610dcf825f83611342565b6001600160a01b0382165f9081526033602052604090205481811015610e425760405162461bcd60e51b815260206004820152602260248201527f45524332303a206275726e20616d6f756e7420657863656564732062616c616e604482015261636560f01b60648201526084016104c7565b6001600160a01b0383165f8181526033602090815260408083208686039055603580548790039055518581529192917fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef9101610cfd565b505050565b5f54610100900460ff16610ec45760405162461bcd60e51b81526004016104c790611b0f565b6108c961142d565b5f54610100900460ff16610ef25760405162461bcd60e51b81526004016104c790611b0f565b610efc828261145c565b5050565b5f54610100900460ff16610f265760405162461bcd60e51b81526004016104c790611b0f565b610be381604051806040016040528060018152602001603160f81b81525061149b565b5f33610f568582856114db565b6109718585856110f5565b5f6107f27f8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f610f8f60655490565b6066546040805160208101859052908101839052606081018290524660808201523060a08201525f9060c0016040516020818303038152906040528051906020012090509392505050565b6001600160a01b0382166110305760405162461bcd60e51b815260206004820152601f60248201527f45524332303a206d696e7420746f20746865207a65726f20616464726573730060448201526064016104c7565b61103b5f8383611342565b8060355f82825461104c9190611af0565b90915550506001600160a01b0382165f818152603360209081526040808320805486019055518481527fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef910160405180910390a35050565b60cc80546001600160a01b038381166001600160a01b0319831681179093556040519116919082907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0905f90a35050565b6001600160a01b0383166111595760405162461bcd60e51b815260206004820152602560248201527f45524332303a207472616e736665722066726f6d20746865207a65726f206164604482015264647265737360d81b60648201526084016104c7565b6001600160a01b0382166111bb5760405162461bcd60e51b815260206004820152602360248201527f45524332303a207472616e7366657220746f20746865207a65726f206164647260448201526265737360e81b60648201526084016104c7565b6111c6838383611342565b6001600160a01b0383165f908152603360205260409020548181101561123d5760405162461bcd60e51b815260206004820152602660248201527f45524332303a207472616e7366657220616d6f756e7420657863656564732062604482015265616c616e636560d01b60648201526084016104c7565b6001600160a01b038085165f8181526033602052604080822086860390559286168082529083902080548601905591517fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef9061129c9086815260200190565b60405180910390a3610664565b6001600160a01b0381165f9081526099602052604090208054600181018255905b50919050565b5f6104566112dc610f61565b8360405161190160f01b602082015260228101839052604281018290525f9060620160405160208183030381529060405280519060200120905092915050565b5f5f5f61132b8787878761154d565b915091506113388161160a565b5095945050505050565b6001600160a01b0383165f90815260fe602052604090205460ff161580611373575060cc546001600160a01b031633145b6113bf5760405162461bcd60e51b815260206004820152601c60248201527f546574686572546f6b656e3a2066726f6d20697320626c6f636b65640000000060448201526064016104c7565b306001600160a01b03831603610e995760405162461bcd60e51b815260206004820152602d60248201527f546574686572546f6b656e3a207472616e7366657220746f2074686520636f6e60448201526c7472616374206164647265737360981b60648201526084016104c7565b5f54610100900460ff166114535760405162461bcd60e51b81526004016104c790611b0f565b6108c9336110a4565b5f54610100900460ff166114825760405162461bcd60e51b81526004016104c790611b0f565b603661148e8382611b9e565b506037610e998282611b9e565b5f54610100900460ff166114c15760405162461bcd60e51b81526004016104c790611b0f565b815160209283012081519190920120606591909155606655565b5f6114e68484610b43565b90505f19811461066457818110156115405760405162461bcd60e51b815260206004820152601d60248201527f45524332303a20696e73756666696369656e7420616c6c6f77616e636500000060448201526064016104c7565b6106648484848403610be6565b5f807f7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a083111561158257505f90506003611601565b604080515f8082526020820180845289905260ff881692820192909252606081018690526080810185905260019060a0016020604051602081039080840390855afa1580156115d3573d5f5f3e3d5ffd5b5050604051601f1901519150506001600160a01b0381166115fb575f60019250925050611601565b91505f90505b94509492505050565b5f81600481111561161d5761161d611c59565b036116255750565b600181600481111561163957611639611c59565b036116865760405162461bcd60e51b815260206004820152601860248201527f45434453413a20696e76616c6964207369676e6174757265000000000000000060448201526064016104c7565b600281600481111561169a5761169a611c59565b036116e75760405162461bcd60e51b815260206004820152601f60248201527f45434453413a20696e76616c6964207369676e6174757265206c656e6774680060448201526064016104c7565b60038160048111156116fb576116fb611c59565b03610be35760405162461bcd60e51b815260206004820152602260248201527f45434453413a20696e76616c6964207369676e6174757265202773272076616c604482015261756560f01b60648201526084016104c7565b602081525f82518060208401528060208501604085015e5f604082850101526040601f19601f83011684010191505092915050565b80356001600160a01b038116811461179e575f5ffd5b919050565b5f5f604083850312156117b4575f5ffd5b6117bd83611788565b946020939093013593505050565b5f602082840312156117db575f5ffd5b6117e482611788565b9392505050565b634e487b7160e01b5f52604160045260245ffd5b5f82601f83011261180e575f5ffd5b813567ffffffffffffffff811115611828576118286117eb565b604051601f8201601f19908116603f0116810167ffffffffffffffff81118282101715611857576118576117eb565b60405281815283820160200185101561186e575f5ffd5b816020850160208301375f918101602001919091529392505050565b803560ff8116811461179e575f5ffd5b5f5f5f606084860312156118ac575f5ffd5b833567ffffffffffffffff8111156118c2575f5ffd5b6118ce868287016117ff565b935050602084013567ffffffffffffffff8111156118ea575f5ffd5b6118f6868287016117ff565b9250506119056040850161188a565b90509250925092565b5f5f83601f84011261191e575f5ffd5b50813567ffffffffffffffff811115611935575f5ffd5b6020830191508360208260051b850101111561194f575f5ffd5b9250929050565b5f5f5f5f60408587031215611969575f5ffd5b843567ffffffffffffffff81111561197f575f5ffd5b61198b8782880161190e565b909550935050602085013567ffffffffffffffff8111156119aa575f5ffd5b6119b68782880161190e565b95989497509550505050565b5f5f5f606084860312156119d4575f5ffd5b6119dd84611788565b92506119eb60208501611788565b929592945050506040919091013590565b5f5f5f5f5f5f5f60e0888a031215611a12575f5ffd5b611a1b88611788565b9650611a2960208901611788565b95506040880135945060608801359350611a456080890161188a565b9699959850939692959460a0840135945060c09093013592915050565b5f60208284031215611a72575f5ffd5b5035919050565b5f5f60408385031215611a8a575f5ffd5b611a9383611788565b9150611aa160208401611788565b90509250929050565b600181811c90821680611abe57607f821691505b6020821081036112ca57634e487b7160e01b5f52602260045260245ffd5b634e487b7160e01b5f52603260045260245ffd5b8082018082111561045657634e487b7160e01b5f52601160045260245ffd5b6020808252602b908201527f496e697469616c697a61626c653a20636f6e7472616374206973206e6f74206960408201526a6e697469616c697a696e6760a81b606082015260800190565b601f821115610e9957805f5260205f20601f840160051c81016020851015611b7f5750805b601f840160051c820191505b81811015610770575f8155600101611b8b565b815167ffffffffffffffff811115611bb857611bb86117eb565b611bcc81611bc68454611aaa565b84611b5a565b6020601f821160018114611bfe575f8315611be75750848201515b5f19600385901b1c1916600184901b178455610770565b5f84815260208120601f198516915b82811015611c2d5787850151825560209485019460019092019101611c0d565b5084821015611c4a57868401515f19600387901b60f8161c191681555b50505050600190811b01905550565b634e487b7160e01b5f52602160045260245ffdfea264697066735822122048ee3968f0d0ce829e3ad80695b891308612ab4aed2b27279f6ef28a6c7d322864736f6c634300081f0033",
+}
+
+// TetherContractTCABI is the input ABI used to generate the binding from.
+// Deprecated: Use TetherContractTCMetaData.ABI instead.
+var TetherContractTCABI = TetherContractTCMetaData.ABI
+
+// TetherContractTCBin is the compiled bytecode used for deploying new contracts.
+// Deprecated: Use TetherContractTCMetaData.Bin instead.
+var TetherContractTCBin = TetherContractTCMetaData.Bin
+
+// DeployTetherContractTC deploys a new kaia contract, binding an instance of TetherContractTC to it.
+func DeployTetherContractTC(auth *bind.TransactOpts, backend bind.ContractBackend) (common.Address, *types.Transaction, *TetherContractTC, error) {
+	parsed, err := TetherContractTCMetaData.GetAbi()
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	if parsed == nil {
+		return common.Address{}, nil, nil, errors.New("GetABI returned nil")
+	}
+
+	address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex(TetherContractTCBin), backend)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &TetherContractTC{TetherContractTCCaller: TetherContractTCCaller{contract: contract}, TetherContractTCTransactor: TetherContractTCTransactor{contract: contract}, TetherContractTCFilterer: TetherContractTCFilterer{contract: contract}}, nil
+}
+
+// TetherContractTC is an auto generated Go binding around an kaia contract.
+type TetherContractTC struct {
+	TetherContractTCCaller     // Read-only binding to the contract
+	TetherContractTCTransactor // Write-only binding to the contract
+	TetherContractTCFilterer   // Log filterer for contract events
+}
+
+// TetherContractTCCaller is an auto generated read-only Go binding around an kaia contract.
+type TetherContractTCCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TetherContractTCTransactor is an auto generated write-only Go binding around an kaia contract.
+type TetherContractTCTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TetherContractTCFilterer is an auto generated log filtering Go binding around an kaia contract events.
+type TetherContractTCFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// TetherContractTCSession is an auto generated Go binding around an kaia contract,
+// with pre-set call and transact options.
+type TetherContractTCSession struct {
+	Contract     *TetherContractTC // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// TetherContractTCCallerSession is an auto generated read-only Go binding around an kaia contract,
+// with pre-set call options.
+type TetherContractTCCallerSession struct {
+	Contract *TetherContractTCCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts           // Call options to use throughout this session
+}
+
+// TetherContractTCTransactorSession is an auto generated write-only Go binding around an kaia contract,
+// with pre-set transact options.
+type TetherContractTCTransactorSession struct {
+	Contract     *TetherContractTCTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts           // Transaction auth options to use throughout this session
+}
+
+// TetherContractTCRaw is an auto generated low-level Go binding around an kaia contract.
+type TetherContractTCRaw struct {
+	Contract *TetherContractTC // Generic contract binding to access the raw methods on
+}
+
+// TetherContractTCCallerRaw is an auto generated low-level read-only Go binding around an kaia contract.
+type TetherContractTCCallerRaw struct {
+	Contract *TetherContractTCCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// TetherContractTCTransactorRaw is an auto generated low-level write-only Go binding around an kaia contract.
+type TetherContractTCTransactorRaw struct {
+	Contract *TetherContractTCTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewTetherContractTC creates a new instance of TetherContractTC, bound to a specific deployed contract.
+func NewTetherContractTC(address common.Address, backend bind.ContractBackend) (*TetherContractTC, error) {
+	contract, err := bindTetherContractTC(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &TetherContractTC{TetherContractTCCaller: TetherContractTCCaller{contract: contract}, TetherContractTCTransactor: TetherContractTCTransactor{contract: contract}, TetherContractTCFilterer: TetherContractTCFilterer{contract: contract}}, nil
+}
+
+// NewTetherContractTCCaller creates a new read-only instance of TetherContractTC, bound to a specific deployed contract.
+func NewTetherContractTCCaller(address common.Address, caller bind.ContractCaller) (*TetherContractTCCaller, error) {
+	contract, err := bindTetherContractTC(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &TetherContractTCCaller{contract: contract}, nil
+}
+
+// NewTetherContractTCTransactor creates a new write-only instance of TetherContractTC, bound to a specific deployed contract.
+func NewTetherContractTCTransactor(address common.Address, transactor bind.ContractTransactor) (*TetherContractTCTransactor, error) {
+	contract, err := bindTetherContractTC(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &TetherContractTCTransactor{contract: contract}, nil
+}
+
+// NewTetherContractTCFilterer creates a new log filterer instance of TetherContractTC, bound to a specific deployed contract.
+func NewTetherContractTCFilterer(address common.Address, filterer bind.ContractFilterer) (*TetherContractTCFilterer, error) {
+	contract, err := bindTetherContractTC(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &TetherContractTCFilterer{contract: contract}, nil
+}
+
+// bindTetherContractTC binds a generic wrapper to an already deployed contract.
+func bindTetherContractTC(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := TetherContractTCMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_TetherContractTC *TetherContractTCRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _TetherContractTC.Contract.TetherContractTCCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_TetherContractTC *TetherContractTCRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.TetherContractTCTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_TetherContractTC *TetherContractTCRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.TetherContractTCTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_TetherContractTC *TetherContractTCCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _TetherContractTC.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_TetherContractTC *TetherContractTCTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_TetherContractTC *TetherContractTCTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.contract.Transact(opts, method, params...)
+}
+
+// DOMAINSEPARATOR is a free data retrieval call binding the contract method 0x3644e515.
+//
+// Solidity: function DOMAIN_SEPARATOR() view returns(bytes32)
+func (_TetherContractTC *TetherContractTCCaller) DOMAINSEPARATOR(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _TetherContractTC.contract.Call(opts, &out, "DOMAIN_SEPARATOR")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// DOMAINSEPARATOR is a free data retrieval call binding the contract method 0x3644e515.
+//
+// Solidity: function DOMAIN_SEPARATOR() view returns(bytes32)
+func (_TetherContractTC *TetherContractTCSession) DOMAINSEPARATOR() ([32]byte, error) {
+	return _TetherContractTC.Contract.DOMAINSEPARATOR(&_TetherContractTC.CallOpts)
+}
+
+// DOMAINSEPARATOR is a free data retrieval call binding the contract method 0x3644e515.
+//
+// Solidity: function DOMAIN_SEPARATOR() view returns(bytes32)
+func (_TetherContractTC *TetherContractTCCallerSession) DOMAINSEPARATOR() ([32]byte, error) {
+	return _TetherContractTC.Contract.DOMAINSEPARATOR(&_TetherContractTC.CallOpts)
+}
+
+// Allowance is a free data retrieval call binding the contract method 0xdd62ed3e.
+//
+// Solidity: function allowance(address owner, address spender) view returns(uint256)
+func (_TetherContractTC *TetherContractTCCaller) Allowance(opts *bind.CallOpts, owner common.Address, spender common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _TetherContractTC.contract.Call(opts, &out, "allowance", owner, spender)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Allowance is a free data retrieval call binding the contract method 0xdd62ed3e.
+//
+// Solidity: function allowance(address owner, address spender) view returns(uint256)
+func (_TetherContractTC *TetherContractTCSession) Allowance(owner common.Address, spender common.Address) (*big.Int, error) {
+	return _TetherContractTC.Contract.Allowance(&_TetherContractTC.CallOpts, owner, spender)
+}
+
+// Allowance is a free data retrieval call binding the contract method 0xdd62ed3e.
+//
+// Solidity: function allowance(address owner, address spender) view returns(uint256)
+func (_TetherContractTC *TetherContractTCCallerSession) Allowance(owner common.Address, spender common.Address) (*big.Int, error) {
+	return _TetherContractTC.Contract.Allowance(&_TetherContractTC.CallOpts, owner, spender)
+}
+
+// BalanceOf is a free data retrieval call binding the contract method 0x70a08231.
+//
+// Solidity: function balanceOf(address account) view returns(uint256)
+func (_TetherContractTC *TetherContractTCCaller) BalanceOf(opts *bind.CallOpts, account common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _TetherContractTC.contract.Call(opts, &out, "balanceOf", account)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// BalanceOf is a free data retrieval call binding the contract method 0x70a08231.
+//
+// Solidity: function balanceOf(address account) view returns(uint256)
+func (_TetherContractTC *TetherContractTCSession) BalanceOf(account common.Address) (*big.Int, error) {
+	return _TetherContractTC.Contract.BalanceOf(&_TetherContractTC.CallOpts, account)
+}
+
+// BalanceOf is a free data retrieval call binding the contract method 0x70a08231.
+//
+// Solidity: function balanceOf(address account) view returns(uint256)
+func (_TetherContractTC *TetherContractTCCallerSession) BalanceOf(account common.Address) (*big.Int, error) {
+	return _TetherContractTC.Contract.BalanceOf(&_TetherContractTC.CallOpts, account)
+}
+
+// Decimals is a free data retrieval call binding the contract method 0x313ce567.
+//
+// Solidity: function decimals() view returns(uint8)
+func (_TetherContractTC *TetherContractTCCaller) Decimals(opts *bind.CallOpts) (uint8, error) {
+	var out []interface{}
+	err := _TetherContractTC.contract.Call(opts, &out, "decimals")
+
+	if err != nil {
+		return *new(uint8), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint8)).(*uint8)
+
+	return out0, err
+
+}
+
+// Decimals is a free data retrieval call binding the contract method 0x313ce567.
+//
+// Solidity: function decimals() view returns(uint8)
+func (_TetherContractTC *TetherContractTCSession) Decimals() (uint8, error) {
+	return _TetherContractTC.Contract.Decimals(&_TetherContractTC.CallOpts)
+}
+
+// Decimals is a free data retrieval call binding the contract method 0x313ce567.
+//
+// Solidity: function decimals() view returns(uint8)
+func (_TetherContractTC *TetherContractTCCallerSession) Decimals() (uint8, error) {
+	return _TetherContractTC.Contract.Decimals(&_TetherContractTC.CallOpts)
+}
+
+// IsBlocked is a free data retrieval call binding the contract method 0xfbac3951.
+//
+// Solidity: function isBlocked(address ) view returns(bool)
+func (_TetherContractTC *TetherContractTCCaller) IsBlocked(opts *bind.CallOpts, arg0 common.Address) (bool, error) {
+	var out []interface{}
+	err := _TetherContractTC.contract.Call(opts, &out, "isBlocked", arg0)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsBlocked is a free data retrieval call binding the contract method 0xfbac3951.
+//
+// Solidity: function isBlocked(address ) view returns(bool)
+func (_TetherContractTC *TetherContractTCSession) IsBlocked(arg0 common.Address) (bool, error) {
+	return _TetherContractTC.Contract.IsBlocked(&_TetherContractTC.CallOpts, arg0)
+}
+
+// IsBlocked is a free data retrieval call binding the contract method 0xfbac3951.
+//
+// Solidity: function isBlocked(address ) view returns(bool)
+func (_TetherContractTC *TetherContractTCCallerSession) IsBlocked(arg0 common.Address) (bool, error) {
+	return _TetherContractTC.Contract.IsBlocked(&_TetherContractTC.CallOpts, arg0)
+}
+
+// IsTrusted is a free data retrieval call binding the contract method 0x96d64879.
+//
+// Solidity: function isTrusted(address ) view returns(bool)
+func (_TetherContractTC *TetherContractTCCaller) IsTrusted(opts *bind.CallOpts, arg0 common.Address) (bool, error) {
+	var out []interface{}
+	err := _TetherContractTC.contract.Call(opts, &out, "isTrusted", arg0)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsTrusted is a free data retrieval call binding the contract method 0x96d64879.
+//
+// Solidity: function isTrusted(address ) view returns(bool)
+func (_TetherContractTC *TetherContractTCSession) IsTrusted(arg0 common.Address) (bool, error) {
+	return _TetherContractTC.Contract.IsTrusted(&_TetherContractTC.CallOpts, arg0)
+}
+
+// IsTrusted is a free data retrieval call binding the contract method 0x96d64879.
+//
+// Solidity: function isTrusted(address ) view returns(bool)
+func (_TetherContractTC *TetherContractTCCallerSession) IsTrusted(arg0 common.Address) (bool, error) {
+	return _TetherContractTC.Contract.IsTrusted(&_TetherContractTC.CallOpts, arg0)
+}
+
+// Name is a free data retrieval call binding the contract method 0x06fdde03.
+//
+// Solidity: function name() view returns(string)
+func (_TetherContractTC *TetherContractTCCaller) Name(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _TetherContractTC.contract.Call(opts, &out, "name")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// Name is a free data retrieval call binding the contract method 0x06fdde03.
+//
+// Solidity: function name() view returns(string)
+func (_TetherContractTC *TetherContractTCSession) Name() (string, error) {
+	return _TetherContractTC.Contract.Name(&_TetherContractTC.CallOpts)
+}
+
+// Name is a free data retrieval call binding the contract method 0x06fdde03.
+//
+// Solidity: function name() view returns(string)
+func (_TetherContractTC *TetherContractTCCallerSession) Name() (string, error) {
+	return _TetherContractTC.Contract.Name(&_TetherContractTC.CallOpts)
+}
+
+// Nonces is a free data retrieval call binding the contract method 0x7ecebe00.
+//
+// Solidity: function nonces(address owner) view returns(uint256)
+func (_TetherContractTC *TetherContractTCCaller) Nonces(opts *bind.CallOpts, owner common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _TetherContractTC.contract.Call(opts, &out, "nonces", owner)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// Nonces is a free data retrieval call binding the contract method 0x7ecebe00.
+//
+// Solidity: function nonces(address owner) view returns(uint256)
+func (_TetherContractTC *TetherContractTCSession) Nonces(owner common.Address) (*big.Int, error) {
+	return _TetherContractTC.Contract.Nonces(&_TetherContractTC.CallOpts, owner)
+}
+
+// Nonces is a free data retrieval call binding the contract method 0x7ecebe00.
+//
+// Solidity: function nonces(address owner) view returns(uint256)
+func (_TetherContractTC *TetherContractTCCallerSession) Nonces(owner common.Address) (*big.Int, error) {
+	return _TetherContractTC.Contract.Nonces(&_TetherContractTC.CallOpts, owner)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_TetherContractTC *TetherContractTCCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _TetherContractTC.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_TetherContractTC *TetherContractTCSession) Owner() (common.Address, error) {
+	return _TetherContractTC.Contract.Owner(&_TetherContractTC.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_TetherContractTC *TetherContractTCCallerSession) Owner() (common.Address, error) {
+	return _TetherContractTC.Contract.Owner(&_TetherContractTC.CallOpts)
+}
+
+// Symbol is a free data retrieval call binding the contract method 0x95d89b41.
+//
+// Solidity: function symbol() view returns(string)
+func (_TetherContractTC *TetherContractTCCaller) Symbol(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _TetherContractTC.contract.Call(opts, &out, "symbol")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// Symbol is a free data retrieval call binding the contract method 0x95d89b41.
+//
+// Solidity: function symbol() view returns(string)
+func (_TetherContractTC *TetherContractTCSession) Symbol() (string, error) {
+	return _TetherContractTC.Contract.Symbol(&_TetherContractTC.CallOpts)
+}
+
+// Symbol is a free data retrieval call binding the contract method 0x95d89b41.
+//
+// Solidity: function symbol() view returns(string)
+func (_TetherContractTC *TetherContractTCCallerSession) Symbol() (string, error) {
+	return _TetherContractTC.Contract.Symbol(&_TetherContractTC.CallOpts)
+}
+
+// TotalSupply is a free data retrieval call binding the contract method 0x18160ddd.
+//
+// Solidity: function totalSupply() view returns(uint256)
+func (_TetherContractTC *TetherContractTCCaller) TotalSupply(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _TetherContractTC.contract.Call(opts, &out, "totalSupply")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// TotalSupply is a free data retrieval call binding the contract method 0x18160ddd.
+//
+// Solidity: function totalSupply() view returns(uint256)
+func (_TetherContractTC *TetherContractTCSession) TotalSupply() (*big.Int, error) {
+	return _TetherContractTC.Contract.TotalSupply(&_TetherContractTC.CallOpts)
+}
+
+// TotalSupply is a free data retrieval call binding the contract method 0x18160ddd.
+//
+// Solidity: function totalSupply() view returns(uint256)
+func (_TetherContractTC *TetherContractTCCallerSession) TotalSupply() (*big.Int, error) {
+	return _TetherContractTC.Contract.TotalSupply(&_TetherContractTC.CallOpts)
+}
+
+// AddToBlockedList is a paid mutator transaction binding the contract method 0x3c7c9b90.
+//
+// Solidity: function addToBlockedList(address _user) returns()
+func (_TetherContractTC *TetherContractTCTransactor) AddToBlockedList(opts *bind.TransactOpts, _user common.Address) (*types.Transaction, error) {
+	return _TetherContractTC.contract.Transact(opts, "addToBlockedList", _user)
+}
+
+// AddToBlockedList is a paid mutator transaction binding the contract method 0x3c7c9b90.
+//
+// Solidity: function addToBlockedList(address _user) returns()
+func (_TetherContractTC *TetherContractTCSession) AddToBlockedList(_user common.Address) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.AddToBlockedList(&_TetherContractTC.TransactOpts, _user)
+}
+
+// AddToBlockedList is a paid mutator transaction binding the contract method 0x3c7c9b90.
+//
+// Solidity: function addToBlockedList(address _user) returns()
+func (_TetherContractTC *TetherContractTCTransactorSession) AddToBlockedList(_user common.Address) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.AddToBlockedList(&_TetherContractTC.TransactOpts, _user)
+}
+
+// Approve is a paid mutator transaction binding the contract method 0x095ea7b3.
+//
+// Solidity: function approve(address spender, uint256 amount) returns(bool)
+func (_TetherContractTC *TetherContractTCTransactor) Approve(opts *bind.TransactOpts, spender common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _TetherContractTC.contract.Transact(opts, "approve", spender, amount)
+}
+
+// Approve is a paid mutator transaction binding the contract method 0x095ea7b3.
+//
+// Solidity: function approve(address spender, uint256 amount) returns(bool)
+func (_TetherContractTC *TetherContractTCSession) Approve(spender common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.Approve(&_TetherContractTC.TransactOpts, spender, amount)
+}
+
+// Approve is a paid mutator transaction binding the contract method 0x095ea7b3.
+//
+// Solidity: function approve(address spender, uint256 amount) returns(bool)
+func (_TetherContractTC *TetherContractTCTransactorSession) Approve(spender common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.Approve(&_TetherContractTC.TransactOpts, spender, amount)
+}
+
+// DecreaseAllowance is a paid mutator transaction binding the contract method 0xa457c2d7.
+//
+// Solidity: function decreaseAllowance(address spender, uint256 subtractedValue) returns(bool)
+func (_TetherContractTC *TetherContractTCTransactor) DecreaseAllowance(opts *bind.TransactOpts, spender common.Address, subtractedValue *big.Int) (*types.Transaction, error) {
+	return _TetherContractTC.contract.Transact(opts, "decreaseAllowance", spender, subtractedValue)
+}
+
+// DecreaseAllowance is a paid mutator transaction binding the contract method 0xa457c2d7.
+//
+// Solidity: function decreaseAllowance(address spender, uint256 subtractedValue) returns(bool)
+func (_TetherContractTC *TetherContractTCSession) DecreaseAllowance(spender common.Address, subtractedValue *big.Int) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.DecreaseAllowance(&_TetherContractTC.TransactOpts, spender, subtractedValue)
+}
+
+// DecreaseAllowance is a paid mutator transaction binding the contract method 0xa457c2d7.
+//
+// Solidity: function decreaseAllowance(address spender, uint256 subtractedValue) returns(bool)
+func (_TetherContractTC *TetherContractTCTransactorSession) DecreaseAllowance(spender common.Address, subtractedValue *big.Int) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.DecreaseAllowance(&_TetherContractTC.TransactOpts, spender, subtractedValue)
+}
+
+// DestroyBlockedFunds is a paid mutator transaction binding the contract method 0x0e27a385.
+//
+// Solidity: function destroyBlockedFunds(address _blockedUser) returns()
+func (_TetherContractTC *TetherContractTCTransactor) DestroyBlockedFunds(opts *bind.TransactOpts, _blockedUser common.Address) (*types.Transaction, error) {
+	return _TetherContractTC.contract.Transact(opts, "destroyBlockedFunds", _blockedUser)
+}
+
+// DestroyBlockedFunds is a paid mutator transaction binding the contract method 0x0e27a385.
+//
+// Solidity: function destroyBlockedFunds(address _blockedUser) returns()
+func (_TetherContractTC *TetherContractTCSession) DestroyBlockedFunds(_blockedUser common.Address) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.DestroyBlockedFunds(&_TetherContractTC.TransactOpts, _blockedUser)
+}
+
+// DestroyBlockedFunds is a paid mutator transaction binding the contract method 0x0e27a385.
+//
+// Solidity: function destroyBlockedFunds(address _blockedUser) returns()
+func (_TetherContractTC *TetherContractTCTransactorSession) DestroyBlockedFunds(_blockedUser common.Address) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.DestroyBlockedFunds(&_TetherContractTC.TransactOpts, _blockedUser)
+}
+
+// IncreaseAllowance is a paid mutator transaction binding the contract method 0x39509351.
+//
+// Solidity: function increaseAllowance(address spender, uint256 addedValue) returns(bool)
+func (_TetherContractTC *TetherContractTCTransactor) IncreaseAllowance(opts *bind.TransactOpts, spender common.Address, addedValue *big.Int) (*types.Transaction, error) {
+	return _TetherContractTC.contract.Transact(opts, "increaseAllowance", spender, addedValue)
+}
+
+// IncreaseAllowance is a paid mutator transaction binding the contract method 0x39509351.
+//
+// Solidity: function increaseAllowance(address spender, uint256 addedValue) returns(bool)
+func (_TetherContractTC *TetherContractTCSession) IncreaseAllowance(spender common.Address, addedValue *big.Int) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.IncreaseAllowance(&_TetherContractTC.TransactOpts, spender, addedValue)
+}
+
+// IncreaseAllowance is a paid mutator transaction binding the contract method 0x39509351.
+//
+// Solidity: function increaseAllowance(address spender, uint256 addedValue) returns(bool)
+func (_TetherContractTC *TetherContractTCTransactorSession) IncreaseAllowance(spender common.Address, addedValue *big.Int) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.IncreaseAllowance(&_TetherContractTC.TransactOpts, spender, addedValue)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x1624f6c6.
+//
+// Solidity: function initialize(string _name, string _symbol, uint8 _decimals) returns()
+func (_TetherContractTC *TetherContractTCTransactor) Initialize(opts *bind.TransactOpts, _name string, _symbol string, _decimals uint8) (*types.Transaction, error) {
+	return _TetherContractTC.contract.Transact(opts, "initialize", _name, _symbol, _decimals)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x1624f6c6.
+//
+// Solidity: function initialize(string _name, string _symbol, uint8 _decimals) returns()
+func (_TetherContractTC *TetherContractTCSession) Initialize(_name string, _symbol string, _decimals uint8) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.Initialize(&_TetherContractTC.TransactOpts, _name, _symbol, _decimals)
+}
+
+// Initialize is a paid mutator transaction binding the contract method 0x1624f6c6.
+//
+// Solidity: function initialize(string _name, string _symbol, uint8 _decimals) returns()
+func (_TetherContractTC *TetherContractTCTransactorSession) Initialize(_name string, _symbol string, _decimals uint8) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.Initialize(&_TetherContractTC.TransactOpts, _name, _symbol, _decimals)
+}
+
+// Mint is a paid mutator transaction binding the contract method 0x40c10f19.
+//
+// Solidity: function mint(address _destination, uint256 _amount) returns()
+func (_TetherContractTC *TetherContractTCTransactor) Mint(opts *bind.TransactOpts, _destination common.Address, _amount *big.Int) (*types.Transaction, error) {
+	return _TetherContractTC.contract.Transact(opts, "mint", _destination, _amount)
+}
+
+// Mint is a paid mutator transaction binding the contract method 0x40c10f19.
+//
+// Solidity: function mint(address _destination, uint256 _amount) returns()
+func (_TetherContractTC *TetherContractTCSession) Mint(_destination common.Address, _amount *big.Int) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.Mint(&_TetherContractTC.TransactOpts, _destination, _amount)
+}
+
+// Mint is a paid mutator transaction binding the contract method 0x40c10f19.
+//
+// Solidity: function mint(address _destination, uint256 _amount) returns()
+func (_TetherContractTC *TetherContractTCTransactorSession) Mint(_destination common.Address, _amount *big.Int) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.Mint(&_TetherContractTC.TransactOpts, _destination, _amount)
+}
+
+// MultiTransfer is a paid mutator transaction binding the contract method 0x1e89d545.
+//
+// Solidity: function multiTransfer(address[] _recipients, uint256[] _values) returns()
+func (_TetherContractTC *TetherContractTCTransactor) MultiTransfer(opts *bind.TransactOpts, _recipients []common.Address, _values []*big.Int) (*types.Transaction, error) {
+	return _TetherContractTC.contract.Transact(opts, "multiTransfer", _recipients, _values)
+}
+
+// MultiTransfer is a paid mutator transaction binding the contract method 0x1e89d545.
+//
+// Solidity: function multiTransfer(address[] _recipients, uint256[] _values) returns()
+func (_TetherContractTC *TetherContractTCSession) MultiTransfer(_recipients []common.Address, _values []*big.Int) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.MultiTransfer(&_TetherContractTC.TransactOpts, _recipients, _values)
+}
+
+// MultiTransfer is a paid mutator transaction binding the contract method 0x1e89d545.
+//
+// Solidity: function multiTransfer(address[] _recipients, uint256[] _values) returns()
+func (_TetherContractTC *TetherContractTCTransactorSession) MultiTransfer(_recipients []common.Address, _values []*big.Int) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.MultiTransfer(&_TetherContractTC.TransactOpts, _recipients, _values)
+}
+
+// Permit is a paid mutator transaction binding the contract method 0xd505accf.
+//
+// Solidity: function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) returns()
+func (_TetherContractTC *TetherContractTCTransactor) Permit(opts *bind.TransactOpts, owner common.Address, spender common.Address, value *big.Int, deadline *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _TetherContractTC.contract.Transact(opts, "permit", owner, spender, value, deadline, v, r, s)
+}
+
+// Permit is a paid mutator transaction binding the contract method 0xd505accf.
+//
+// Solidity: function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) returns()
+func (_TetherContractTC *TetherContractTCSession) Permit(owner common.Address, spender common.Address, value *big.Int, deadline *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.Permit(&_TetherContractTC.TransactOpts, owner, spender, value, deadline, v, r, s)
+}
+
+// Permit is a paid mutator transaction binding the contract method 0xd505accf.
+//
+// Solidity: function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) returns()
+func (_TetherContractTC *TetherContractTCTransactorSession) Permit(owner common.Address, spender common.Address, value *big.Int, deadline *big.Int, v uint8, r [32]byte, s [32]byte) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.Permit(&_TetherContractTC.TransactOpts, owner, spender, value, deadline, v, r, s)
+}
+
+// Redeem is a paid mutator transaction binding the contract method 0xdb006a75.
+//
+// Solidity: function redeem(uint256 _amount) returns()
+func (_TetherContractTC *TetherContractTCTransactor) Redeem(opts *bind.TransactOpts, _amount *big.Int) (*types.Transaction, error) {
+	return _TetherContractTC.contract.Transact(opts, "redeem", _amount)
+}
+
+// Redeem is a paid mutator transaction binding the contract method 0xdb006a75.
+//
+// Solidity: function redeem(uint256 _amount) returns()
+func (_TetherContractTC *TetherContractTCSession) Redeem(_amount *big.Int) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.Redeem(&_TetherContractTC.TransactOpts, _amount)
+}
+
+// Redeem is a paid mutator transaction binding the contract method 0xdb006a75.
+//
+// Solidity: function redeem(uint256 _amount) returns()
+func (_TetherContractTC *TetherContractTCTransactorSession) Redeem(_amount *big.Int) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.Redeem(&_TetherContractTC.TransactOpts, _amount)
+}
+
+// RemoveFromBlockedList is a paid mutator transaction binding the contract method 0x1a14f449.
+//
+// Solidity: function removeFromBlockedList(address _user) returns()
+func (_TetherContractTC *TetherContractTCTransactor) RemoveFromBlockedList(opts *bind.TransactOpts, _user common.Address) (*types.Transaction, error) {
+	return _TetherContractTC.contract.Transact(opts, "removeFromBlockedList", _user)
+}
+
+// RemoveFromBlockedList is a paid mutator transaction binding the contract method 0x1a14f449.
+//
+// Solidity: function removeFromBlockedList(address _user) returns()
+func (_TetherContractTC *TetherContractTCSession) RemoveFromBlockedList(_user common.Address) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.RemoveFromBlockedList(&_TetherContractTC.TransactOpts, _user)
+}
+
+// RemoveFromBlockedList is a paid mutator transaction binding the contract method 0x1a14f449.
+//
+// Solidity: function removeFromBlockedList(address _user) returns()
+func (_TetherContractTC *TetherContractTCTransactorSession) RemoveFromBlockedList(_user common.Address) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.RemoveFromBlockedList(&_TetherContractTC.TransactOpts, _user)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_TetherContractTC *TetherContractTCTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _TetherContractTC.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_TetherContractTC *TetherContractTCSession) RenounceOwnership() (*types.Transaction, error) {
+	return _TetherContractTC.Contract.RenounceOwnership(&_TetherContractTC.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_TetherContractTC *TetherContractTCTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _TetherContractTC.Contract.RenounceOwnership(&_TetherContractTC.TransactOpts)
+}
+
+// Transfer is a paid mutator transaction binding the contract method 0xa9059cbb.
+//
+// Solidity: function transfer(address to, uint256 amount) returns(bool)
+func (_TetherContractTC *TetherContractTCTransactor) Transfer(opts *bind.TransactOpts, to common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _TetherContractTC.contract.Transact(opts, "transfer", to, amount)
+}
+
+// Transfer is a paid mutator transaction binding the contract method 0xa9059cbb.
+//
+// Solidity: function transfer(address to, uint256 amount) returns(bool)
+func (_TetherContractTC *TetherContractTCSession) Transfer(to common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.Transfer(&_TetherContractTC.TransactOpts, to, amount)
+}
+
+// Transfer is a paid mutator transaction binding the contract method 0xa9059cbb.
+//
+// Solidity: function transfer(address to, uint256 amount) returns(bool)
+func (_TetherContractTC *TetherContractTCTransactorSession) Transfer(to common.Address, amount *big.Int) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.Transfer(&_TetherContractTC.TransactOpts, to, amount)
+}
+
+// TransferFrom is a paid mutator transaction binding the contract method 0x23b872dd.
+//
+// Solidity: function transferFrom(address _sender, address _recipient, uint256 _amount) returns(bool)
+func (_TetherContractTC *TetherContractTCTransactor) TransferFrom(opts *bind.TransactOpts, _sender common.Address, _recipient common.Address, _amount *big.Int) (*types.Transaction, error) {
+	return _TetherContractTC.contract.Transact(opts, "transferFrom", _sender, _recipient, _amount)
+}
+
+// TransferFrom is a paid mutator transaction binding the contract method 0x23b872dd.
+//
+// Solidity: function transferFrom(address _sender, address _recipient, uint256 _amount) returns(bool)
+func (_TetherContractTC *TetherContractTCSession) TransferFrom(_sender common.Address, _recipient common.Address, _amount *big.Int) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.TransferFrom(&_TetherContractTC.TransactOpts, _sender, _recipient, _amount)
+}
+
+// TransferFrom is a paid mutator transaction binding the contract method 0x23b872dd.
+//
+// Solidity: function transferFrom(address _sender, address _recipient, uint256 _amount) returns(bool)
+func (_TetherContractTC *TetherContractTCTransactorSession) TransferFrom(_sender common.Address, _recipient common.Address, _amount *big.Int) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.TransferFrom(&_TetherContractTC.TransactOpts, _sender, _recipient, _amount)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_TetherContractTC *TetherContractTCTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _TetherContractTC.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_TetherContractTC *TetherContractTCSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.TransferOwnership(&_TetherContractTC.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_TetherContractTC *TetherContractTCTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _TetherContractTC.Contract.TransferOwnership(&_TetherContractTC.TransactOpts, newOwner)
+}
+
+// TetherContractTCApprovalIterator is returned from FilterApproval and is used to iterate over the raw logs and unpacked data for Approval events raised by the TetherContractTC contract.
+type TetherContractTCApprovalIterator struct {
+	Event *TetherContractTCApproval // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  kaia.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TetherContractTCApprovalIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TetherContractTCApproval)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TetherContractTCApproval)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TetherContractTCApprovalIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TetherContractTCApprovalIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TetherContractTCApproval represents a Approval event raised by the TetherContractTC contract.
+type TetherContractTCApproval struct {
+	Owner   common.Address
+	Spender common.Address
+	Value   *big.Int
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterApproval is a free log retrieval operation binding the contract event 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925.
+//
+// Solidity: event Approval(address indexed owner, address indexed spender, uint256 value)
+func (_TetherContractTC *TetherContractTCFilterer) FilterApproval(opts *bind.FilterOpts, owner []common.Address, spender []common.Address) (*TetherContractTCApprovalIterator, error) {
+
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+	var spenderRule []interface{}
+	for _, spenderItem := range spender {
+		spenderRule = append(spenderRule, spenderItem)
+	}
+
+	logs, sub, err := _TetherContractTC.contract.FilterLogs(opts, "Approval", ownerRule, spenderRule)
+	if err != nil {
+		return nil, err
+	}
+	return &TetherContractTCApprovalIterator{contract: _TetherContractTC.contract, event: "Approval", logs: logs, sub: sub}, nil
+}
+
+// WatchApproval is a free log subscription operation binding the contract event 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925.
+//
+// Solidity: event Approval(address indexed owner, address indexed spender, uint256 value)
+func (_TetherContractTC *TetherContractTCFilterer) WatchApproval(opts *bind.WatchOpts, sink chan<- *TetherContractTCApproval, owner []common.Address, spender []common.Address) (event.Subscription, error) {
+
+	var ownerRule []interface{}
+	for _, ownerItem := range owner {
+		ownerRule = append(ownerRule, ownerItem)
+	}
+	var spenderRule []interface{}
+	for _, spenderItem := range spender {
+		spenderRule = append(spenderRule, spenderItem)
+	}
+
+	logs, sub, err := _TetherContractTC.contract.WatchLogs(opts, "Approval", ownerRule, spenderRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TetherContractTCApproval)
+				if err := _TetherContractTC.contract.UnpackLog(event, "Approval", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseApproval is a log parse operation binding the contract event 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925.
+//
+// Solidity: event Approval(address indexed owner, address indexed spender, uint256 value)
+func (_TetherContractTC *TetherContractTCFilterer) ParseApproval(log types.Log) (*TetherContractTCApproval, error) {
+	event := new(TetherContractTCApproval)
+	if err := _TetherContractTC.contract.UnpackLog(event, "Approval", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// TetherContractTCBlockPlacedIterator is returned from FilterBlockPlaced and is used to iterate over the raw logs and unpacked data for BlockPlaced events raised by the TetherContractTC contract.
+type TetherContractTCBlockPlacedIterator struct {
+	Event *TetherContractTCBlockPlaced // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  kaia.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TetherContractTCBlockPlacedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TetherContractTCBlockPlaced)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TetherContractTCBlockPlaced)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TetherContractTCBlockPlacedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TetherContractTCBlockPlacedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TetherContractTCBlockPlaced represents a BlockPlaced event raised by the TetherContractTC contract.
+type TetherContractTCBlockPlaced struct {
+	User common.Address
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterBlockPlaced is a free log retrieval operation binding the contract event 0x406bbf2d8d145125adf1198d2cf8a67c66cc4bb0ab01c37dccd4f7c0aae1e7c7.
+//
+// Solidity: event BlockPlaced(address indexed _user)
+func (_TetherContractTC *TetherContractTCFilterer) FilterBlockPlaced(opts *bind.FilterOpts, _user []common.Address) (*TetherContractTCBlockPlacedIterator, error) {
+
+	var _userRule []interface{}
+	for _, _userItem := range _user {
+		_userRule = append(_userRule, _userItem)
+	}
+
+	logs, sub, err := _TetherContractTC.contract.FilterLogs(opts, "BlockPlaced", _userRule)
+	if err != nil {
+		return nil, err
+	}
+	return &TetherContractTCBlockPlacedIterator{contract: _TetherContractTC.contract, event: "BlockPlaced", logs: logs, sub: sub}, nil
+}
+
+// WatchBlockPlaced is a free log subscription operation binding the contract event 0x406bbf2d8d145125adf1198d2cf8a67c66cc4bb0ab01c37dccd4f7c0aae1e7c7.
+//
+// Solidity: event BlockPlaced(address indexed _user)
+func (_TetherContractTC *TetherContractTCFilterer) WatchBlockPlaced(opts *bind.WatchOpts, sink chan<- *TetherContractTCBlockPlaced, _user []common.Address) (event.Subscription, error) {
+
+	var _userRule []interface{}
+	for _, _userItem := range _user {
+		_userRule = append(_userRule, _userItem)
+	}
+
+	logs, sub, err := _TetherContractTC.contract.WatchLogs(opts, "BlockPlaced", _userRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TetherContractTCBlockPlaced)
+				if err := _TetherContractTC.contract.UnpackLog(event, "BlockPlaced", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBlockPlaced is a log parse operation binding the contract event 0x406bbf2d8d145125adf1198d2cf8a67c66cc4bb0ab01c37dccd4f7c0aae1e7c7.
+//
+// Solidity: event BlockPlaced(address indexed _user)
+func (_TetherContractTC *TetherContractTCFilterer) ParseBlockPlaced(log types.Log) (*TetherContractTCBlockPlaced, error) {
+	event := new(TetherContractTCBlockPlaced)
+	if err := _TetherContractTC.contract.UnpackLog(event, "BlockPlaced", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// TetherContractTCBlockReleasedIterator is returned from FilterBlockReleased and is used to iterate over the raw logs and unpacked data for BlockReleased events raised by the TetherContractTC contract.
+type TetherContractTCBlockReleasedIterator struct {
+	Event *TetherContractTCBlockReleased // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  kaia.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TetherContractTCBlockReleasedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TetherContractTCBlockReleased)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TetherContractTCBlockReleased)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TetherContractTCBlockReleasedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TetherContractTCBlockReleasedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TetherContractTCBlockReleased represents a BlockReleased event raised by the TetherContractTC contract.
+type TetherContractTCBlockReleased struct {
+	User common.Address
+	Raw  types.Log // Blockchain specific contextual infos
+}
+
+// FilterBlockReleased is a free log retrieval operation binding the contract event 0x665918c9e02eb2fd85acca3969cb054fc84c138e60ec4af22ab6ef2fd4c93c27.
+//
+// Solidity: event BlockReleased(address indexed _user)
+func (_TetherContractTC *TetherContractTCFilterer) FilterBlockReleased(opts *bind.FilterOpts, _user []common.Address) (*TetherContractTCBlockReleasedIterator, error) {
+
+	var _userRule []interface{}
+	for _, _userItem := range _user {
+		_userRule = append(_userRule, _userItem)
+	}
+
+	logs, sub, err := _TetherContractTC.contract.FilterLogs(opts, "BlockReleased", _userRule)
+	if err != nil {
+		return nil, err
+	}
+	return &TetherContractTCBlockReleasedIterator{contract: _TetherContractTC.contract, event: "BlockReleased", logs: logs, sub: sub}, nil
+}
+
+// WatchBlockReleased is a free log subscription operation binding the contract event 0x665918c9e02eb2fd85acca3969cb054fc84c138e60ec4af22ab6ef2fd4c93c27.
+//
+// Solidity: event BlockReleased(address indexed _user)
+func (_TetherContractTC *TetherContractTCFilterer) WatchBlockReleased(opts *bind.WatchOpts, sink chan<- *TetherContractTCBlockReleased, _user []common.Address) (event.Subscription, error) {
+
+	var _userRule []interface{}
+	for _, _userItem := range _user {
+		_userRule = append(_userRule, _userItem)
+	}
+
+	logs, sub, err := _TetherContractTC.contract.WatchLogs(opts, "BlockReleased", _userRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TetherContractTCBlockReleased)
+				if err := _TetherContractTC.contract.UnpackLog(event, "BlockReleased", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBlockReleased is a log parse operation binding the contract event 0x665918c9e02eb2fd85acca3969cb054fc84c138e60ec4af22ab6ef2fd4c93c27.
+//
+// Solidity: event BlockReleased(address indexed _user)
+func (_TetherContractTC *TetherContractTCFilterer) ParseBlockReleased(log types.Log) (*TetherContractTCBlockReleased, error) {
+	event := new(TetherContractTCBlockReleased)
+	if err := _TetherContractTC.contract.UnpackLog(event, "BlockReleased", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// TetherContractTCDestroyedBlockedFundsIterator is returned from FilterDestroyedBlockedFunds and is used to iterate over the raw logs and unpacked data for DestroyedBlockedFunds events raised by the TetherContractTC contract.
+type TetherContractTCDestroyedBlockedFundsIterator struct {
+	Event *TetherContractTCDestroyedBlockedFunds // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  kaia.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TetherContractTCDestroyedBlockedFundsIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TetherContractTCDestroyedBlockedFunds)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TetherContractTCDestroyedBlockedFunds)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TetherContractTCDestroyedBlockedFundsIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TetherContractTCDestroyedBlockedFundsIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TetherContractTCDestroyedBlockedFunds represents a DestroyedBlockedFunds event raised by the TetherContractTC contract.
+type TetherContractTCDestroyedBlockedFunds struct {
+	BlockedUser common.Address
+	Balance     *big.Int
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterDestroyedBlockedFunds is a free log retrieval operation binding the contract event 0x6a2859ae7902313752498feb80a014e6e7275fe964c79aa965db815db1c7f1e9.
+//
+// Solidity: event DestroyedBlockedFunds(address indexed _blockedUser, uint256 _balance)
+func (_TetherContractTC *TetherContractTCFilterer) FilterDestroyedBlockedFunds(opts *bind.FilterOpts, _blockedUser []common.Address) (*TetherContractTCDestroyedBlockedFundsIterator, error) {
+
+	var _blockedUserRule []interface{}
+	for _, _blockedUserItem := range _blockedUser {
+		_blockedUserRule = append(_blockedUserRule, _blockedUserItem)
+	}
+
+	logs, sub, err := _TetherContractTC.contract.FilterLogs(opts, "DestroyedBlockedFunds", _blockedUserRule)
+	if err != nil {
+		return nil, err
+	}
+	return &TetherContractTCDestroyedBlockedFundsIterator{contract: _TetherContractTC.contract, event: "DestroyedBlockedFunds", logs: logs, sub: sub}, nil
+}
+
+// WatchDestroyedBlockedFunds is a free log subscription operation binding the contract event 0x6a2859ae7902313752498feb80a014e6e7275fe964c79aa965db815db1c7f1e9.
+//
+// Solidity: event DestroyedBlockedFunds(address indexed _blockedUser, uint256 _balance)
+func (_TetherContractTC *TetherContractTCFilterer) WatchDestroyedBlockedFunds(opts *bind.WatchOpts, sink chan<- *TetherContractTCDestroyedBlockedFunds, _blockedUser []common.Address) (event.Subscription, error) {
+
+	var _blockedUserRule []interface{}
+	for _, _blockedUserItem := range _blockedUser {
+		_blockedUserRule = append(_blockedUserRule, _blockedUserItem)
+	}
+
+	logs, sub, err := _TetherContractTC.contract.WatchLogs(opts, "DestroyedBlockedFunds", _blockedUserRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TetherContractTCDestroyedBlockedFunds)
+				if err := _TetherContractTC.contract.UnpackLog(event, "DestroyedBlockedFunds", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseDestroyedBlockedFunds is a log parse operation binding the contract event 0x6a2859ae7902313752498feb80a014e6e7275fe964c79aa965db815db1c7f1e9.
+//
+// Solidity: event DestroyedBlockedFunds(address indexed _blockedUser, uint256 _balance)
+func (_TetherContractTC *TetherContractTCFilterer) ParseDestroyedBlockedFunds(log types.Log) (*TetherContractTCDestroyedBlockedFunds, error) {
+	event := new(TetherContractTCDestroyedBlockedFunds)
+	if err := _TetherContractTC.contract.UnpackLog(event, "DestroyedBlockedFunds", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// TetherContractTCInitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the TetherContractTC contract.
+type TetherContractTCInitializedIterator struct {
+	Event *TetherContractTCInitialized // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  kaia.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TetherContractTCInitializedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TetherContractTCInitialized)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TetherContractTCInitialized)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TetherContractTCInitializedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TetherContractTCInitializedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TetherContractTCInitialized represents a Initialized event raised by the TetherContractTC contract.
+type TetherContractTCInitialized struct {
+	Version uint8
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterInitialized is a free log retrieval operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_TetherContractTC *TetherContractTCFilterer) FilterInitialized(opts *bind.FilterOpts) (*TetherContractTCInitializedIterator, error) {
+
+	logs, sub, err := _TetherContractTC.contract.FilterLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return &TetherContractTCInitializedIterator{contract: _TetherContractTC.contract, event: "Initialized", logs: logs, sub: sub}, nil
+}
+
+// WatchInitialized is a free log subscription operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_TetherContractTC *TetherContractTCFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *TetherContractTCInitialized) (event.Subscription, error) {
+
+	logs, sub, err := _TetherContractTC.contract.WatchLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TetherContractTCInitialized)
+				if err := _TetherContractTC.contract.UnpackLog(event, "Initialized", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseInitialized is a log parse operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_TetherContractTC *TetherContractTCFilterer) ParseInitialized(log types.Log) (*TetherContractTCInitialized, error) {
+	event := new(TetherContractTCInitialized)
+	if err := _TetherContractTC.contract.UnpackLog(event, "Initialized", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// TetherContractTCMintIterator is returned from FilterMint and is used to iterate over the raw logs and unpacked data for Mint events raised by the TetherContractTC contract.
+type TetherContractTCMintIterator struct {
+	Event *TetherContractTCMint // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  kaia.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TetherContractTCMintIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TetherContractTCMint)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TetherContractTCMint)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TetherContractTCMintIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TetherContractTCMintIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TetherContractTCMint represents a Mint event raised by the TetherContractTC contract.
+type TetherContractTCMint struct {
+	Destination common.Address
+	Amount      *big.Int
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterMint is a free log retrieval operation binding the contract event 0x0f6798a560793a54c3bcfe86a93cde1e73087d944c0ea20544137d4121396885.
+//
+// Solidity: event Mint(address indexed _destination, uint256 _amount)
+func (_TetherContractTC *TetherContractTCFilterer) FilterMint(opts *bind.FilterOpts, _destination []common.Address) (*TetherContractTCMintIterator, error) {
+
+	var _destinationRule []interface{}
+	for _, _destinationItem := range _destination {
+		_destinationRule = append(_destinationRule, _destinationItem)
+	}
+
+	logs, sub, err := _TetherContractTC.contract.FilterLogs(opts, "Mint", _destinationRule)
+	if err != nil {
+		return nil, err
+	}
+	return &TetherContractTCMintIterator{contract: _TetherContractTC.contract, event: "Mint", logs: logs, sub: sub}, nil
+}
+
+// WatchMint is a free log subscription operation binding the contract event 0x0f6798a560793a54c3bcfe86a93cde1e73087d944c0ea20544137d4121396885.
+//
+// Solidity: event Mint(address indexed _destination, uint256 _amount)
+func (_TetherContractTC *TetherContractTCFilterer) WatchMint(opts *bind.WatchOpts, sink chan<- *TetherContractTCMint, _destination []common.Address) (event.Subscription, error) {
+
+	var _destinationRule []interface{}
+	for _, _destinationItem := range _destination {
+		_destinationRule = append(_destinationRule, _destinationItem)
+	}
+
+	logs, sub, err := _TetherContractTC.contract.WatchLogs(opts, "Mint", _destinationRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TetherContractTCMint)
+				if err := _TetherContractTC.contract.UnpackLog(event, "Mint", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseMint is a log parse operation binding the contract event 0x0f6798a560793a54c3bcfe86a93cde1e73087d944c0ea20544137d4121396885.
+//
+// Solidity: event Mint(address indexed _destination, uint256 _amount)
+func (_TetherContractTC *TetherContractTCFilterer) ParseMint(log types.Log) (*TetherContractTCMint, error) {
+	event := new(TetherContractTCMint)
+	if err := _TetherContractTC.contract.UnpackLog(event, "Mint", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// TetherContractTCOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the TetherContractTC contract.
+type TetherContractTCOwnershipTransferredIterator struct {
+	Event *TetherContractTCOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  kaia.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TetherContractTCOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TetherContractTCOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TetherContractTCOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TetherContractTCOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TetherContractTCOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TetherContractTCOwnershipTransferred represents a OwnershipTransferred event raised by the TetherContractTC contract.
+type TetherContractTCOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_TetherContractTC *TetherContractTCFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*TetherContractTCOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _TetherContractTC.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &TetherContractTCOwnershipTransferredIterator{contract: _TetherContractTC.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_TetherContractTC *TetherContractTCFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *TetherContractTCOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _TetherContractTC.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TetherContractTCOwnershipTransferred)
+				if err := _TetherContractTC.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_TetherContractTC *TetherContractTCFilterer) ParseOwnershipTransferred(log types.Log) (*TetherContractTCOwnershipTransferred, error) {
+	event := new(TetherContractTCOwnershipTransferred)
+	if err := _TetherContractTC.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// TetherContractTCRedeemIterator is returned from FilterRedeem and is used to iterate over the raw logs and unpacked data for Redeem events raised by the TetherContractTC contract.
+type TetherContractTCRedeemIterator struct {
+	Event *TetherContractTCRedeem // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  kaia.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TetherContractTCRedeemIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TetherContractTCRedeem)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TetherContractTCRedeem)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TetherContractTCRedeemIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TetherContractTCRedeemIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TetherContractTCRedeem represents a Redeem event raised by the TetherContractTC contract.
+type TetherContractTCRedeem struct {
+	Amount *big.Int
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterRedeem is a free log retrieval operation binding the contract event 0x702d5967f45f6513a38ffc42d6ba9bf230bd40e8f53b16363c7eb4fd2deb9a44.
+//
+// Solidity: event Redeem(uint256 _amount)
+func (_TetherContractTC *TetherContractTCFilterer) FilterRedeem(opts *bind.FilterOpts) (*TetherContractTCRedeemIterator, error) {
+
+	logs, sub, err := _TetherContractTC.contract.FilterLogs(opts, "Redeem")
+	if err != nil {
+		return nil, err
+	}
+	return &TetherContractTCRedeemIterator{contract: _TetherContractTC.contract, event: "Redeem", logs: logs, sub: sub}, nil
+}
+
+// WatchRedeem is a free log subscription operation binding the contract event 0x702d5967f45f6513a38ffc42d6ba9bf230bd40e8f53b16363c7eb4fd2deb9a44.
+//
+// Solidity: event Redeem(uint256 _amount)
+func (_TetherContractTC *TetherContractTCFilterer) WatchRedeem(opts *bind.WatchOpts, sink chan<- *TetherContractTCRedeem) (event.Subscription, error) {
+
+	logs, sub, err := _TetherContractTC.contract.WatchLogs(opts, "Redeem")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TetherContractTCRedeem)
+				if err := _TetherContractTC.contract.UnpackLog(event, "Redeem", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseRedeem is a log parse operation binding the contract event 0x702d5967f45f6513a38ffc42d6ba9bf230bd40e8f53b16363c7eb4fd2deb9a44.
+//
+// Solidity: event Redeem(uint256 _amount)
+func (_TetherContractTC *TetherContractTCFilterer) ParseRedeem(log types.Log) (*TetherContractTCRedeem, error) {
+	event := new(TetherContractTCRedeem)
+	if err := _TetherContractTC.contract.UnpackLog(event, "Redeem", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// TetherContractTCTransferIterator is returned from FilterTransfer and is used to iterate over the raw logs and unpacked data for Transfer events raised by the TetherContractTC contract.
+type TetherContractTCTransferIterator struct {
+	Event *TetherContractTCTransfer // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  kaia.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *TetherContractTCTransferIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(TetherContractTCTransfer)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(TetherContractTCTransfer)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *TetherContractTCTransferIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *TetherContractTCTransferIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// TetherContractTCTransfer represents a Transfer event raised by the TetherContractTC contract.
+type TetherContractTCTransfer struct {
+	From  common.Address
+	To    common.Address
+	Value *big.Int
+	Raw   types.Log // Blockchain specific contextual infos
+}
+
+// FilterTransfer is a free log retrieval operation binding the contract event 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef.
+//
+// Solidity: event Transfer(address indexed from, address indexed to, uint256 value)
+func (_TetherContractTC *TetherContractTCFilterer) FilterTransfer(opts *bind.FilterOpts, from []common.Address, to []common.Address) (*TetherContractTCTransferIterator, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _TetherContractTC.contract.FilterLogs(opts, "Transfer", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return &TetherContractTCTransferIterator{contract: _TetherContractTC.contract, event: "Transfer", logs: logs, sub: sub}, nil
+}
+
+// WatchTransfer is a free log subscription operation binding the contract event 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef.
+//
+// Solidity: event Transfer(address indexed from, address indexed to, uint256 value)
+func (_TetherContractTC *TetherContractTCFilterer) WatchTransfer(opts *bind.WatchOpts, sink chan<- *TetherContractTCTransfer, from []common.Address, to []common.Address) (event.Subscription, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _TetherContractTC.contract.WatchLogs(opts, "Transfer", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(TetherContractTCTransfer)
+				if err := _TetherContractTC.contract.UnpackLog(event, "Transfer", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseTransfer is a log parse operation binding the contract event 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef.
+//
+// Solidity: event Transfer(address indexed from, address indexed to, uint256 value)
+func (_TetherContractTC *TetherContractTCFilterer) ParseTransfer(log types.Log) (*TetherContractTCTransfer, error) {
+	event := new(TetherContractTCTransfer)
+	if err := _TetherContractTC.contract.UnpackLog(event, "Transfer", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/klayslave/account/contracts/tetherContract/tetherToken.sol
+++ b/klayslave/account/contracts/tetherContract/tetherToken.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache 2.0
+
+pragma solidity ^0.8.4;
+
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-ERC20PermitUpgradeable.sol";
+import "./WithBlockedList.sol";
+
+/*
+
+   Copyright Tether.to 2024
+
+   Version 2.0(a)
+
+   Licensed under the Apache License, Version 2.0
+   http://www.apache.org/licenses/LICENSE-2.0
+
+*/
+
+contract TetherToken is
+    Initializable,
+    ERC20PermitUpgradeable,
+    OwnableUpgradeable,
+    WithBlockedList
+{
+    // Unused variable retained to preserve storage slots across upgrades
+    mapping(address => bool) public isTrusted;
+
+    uint8 private tetherDecimals;
+
+    function initialize(
+        string memory _name,
+        string memory _symbol,
+        uint8 _decimals
+    ) public initializer {
+        tetherDecimals = _decimals;
+        __Ownable_init();
+        __ERC20_init(_name, _symbol);
+        __ERC20Permit_init(_name);
+    }
+
+    function decimals() public view virtual override returns (uint8) {
+        return tetherDecimals;
+    }
+
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256
+    ) internal virtual override {
+        require(!isBlocked[from] || msg.sender == owner(), "TetherToken: from is blocked");
+        require( 
+            to != address(this), 
+            "TetherToken: transfer to the contract address" 
+        ); 
+    }
+
+    function transferFrom(
+        address _sender,
+        address _recipient,
+        uint256 _amount
+    ) public virtual override onlyNotBlocked returns (bool) {
+        return super.transferFrom(_sender, _recipient, _amount);
+    }
+
+    function multiTransfer (
+        address[] calldata _recipients,
+        uint256[] calldata _values
+    ) external {
+        require(
+            _recipients.length == _values.length,
+            "TetherToken: multiTransfer mismatch"
+        );
+        for (uint256 i = 0; i < _recipients.length; i++) {
+            transfer(_recipients[i], _values[i]);
+        }
+    }
+
+    function mint(address _destination, uint256 _amount) public onlyOwner {
+        _mint(_destination, _amount);
+        emit Mint(_destination, _amount);
+    }
+
+    function redeem(uint256 _amount) public onlyOwner {
+        _burn(owner(), _amount);
+        emit Redeem(_amount);
+    }
+
+    function destroyBlockedFunds(address _blockedUser) public onlyOwner {
+        require(isBlocked[_blockedUser], "TetherToken: user is not blocked");
+        uint256 blockedFunds = balanceOf(_blockedUser);
+        _burn(_blockedUser, blockedFunds);
+        emit DestroyedBlockedFunds(_blockedUser, blockedFunds);
+    }
+
+    event Mint(address indexed _destination, uint256 _amount);
+    event Redeem(uint256 _amount);
+    event DestroyedBlockedFunds(address indexed _blockedUser, uint256 _balance);
+}

--- a/klayslave/account/contracts/tetherContract/tetherTokenFlattened.sol
+++ b/klayslave/account/contracts/tetherContract/tetherTokenFlattened.sol
@@ -1,0 +1,1180 @@
+// SPDX-License-Identifier: Apache 2.0
+pragma solidity ^0.8.4;
+
+// node_modules/@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol
+
+/**
+ * @title Counters
+ * @author Matt Condon (@shrugs)
+ * @dev Provides counters that can only be incremented, decremented or reset. This can be used e.g. to track the number
+ * of elements in a mapping, issuing ERC721 ids, or counting request ids.
+ *
+ * Include with `using Counters for Counters.Counter;`
+ */
+library CountersUpgradeable {
+    struct Counter {
+        // This variable should never be directly accessed by users of the library: interactions must be restricted to
+        // the library's function. As of Solidity v0.5.2, this cannot be enforced, though there is a proposal to add
+        // this feature: see https://github.com/ethereum/solidity/issues/4637
+        uint256 _value; // default: 0
+    }
+
+    function current(Counter storage counter) internal view returns (uint256) {
+        return counter._value;
+    }
+
+    function increment(Counter storage counter) internal {
+        unchecked {
+            counter._value += 1;
+        }
+    }
+
+    function decrement(Counter storage counter) internal {
+        uint256 value = counter._value;
+        require(value > 0, "Counter: decrement overflow");
+        unchecked {
+            counter._value = value - 1;
+        }
+    }
+
+    function reset(Counter storage counter) internal {
+        counter._value = 0;
+    }
+}
+
+// node_modules/@openzeppelin/contracts-upgradeable/utils/cryptography/ECDSAUpgradeable.sol
+
+/**
+ * @dev Elliptic Curve Digital Signature Algorithm (ECDSA) operations.
+ *
+ * These functions can be used to verify that a message was signed by the holder
+ * of the private keys of a given address.
+ */
+library ECDSAUpgradeable {
+    /**
+     * @dev Returns the address that signed a hashed message (`hash`) with
+     * `signature`. This address can then be used for verification purposes.
+     *
+     * The `ecrecover` EVM opcode allows for malleable (non-unique) signatures:
+     * this function rejects them by requiring the `s` value to be in the lower
+     * half order, and the `v` value to be either 27 or 28.
+     *
+     * IMPORTANT: `hash` _must_ be the result of a hash operation for the
+     * verification to be secure: it is possible to craft signatures that
+     * recover to arbitrary addresses for non-hashed data. A safe way to ensure
+     * this is by receiving a hash of the original message (which may otherwise
+     * be too long), and then calling {toEthSignedMessageHash} on it.
+     *
+     * Documentation for signature generation:
+     * - with https://web3js.readthedocs.io/en/v1.3.4/web3-eth-accounts.html#sign[Web3.js]
+     * - with https://docs.ethers.io/v5/api/signer/#Signer-signMessage[ethers]
+     */
+    function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {
+        // Check the signature length
+        // - case 65: r,s,v signature (standard)
+        // - case 64: r,vs signature (cf https://eips.ethereum.org/EIPS/eip-2098) _Available since v4.1._
+        if (signature.length == 65) {
+            bytes32 r;
+            bytes32 s;
+            uint8 v;
+            // ecrecover takes the signature parameters, and the only way to get them
+            // currently is to use assembly.
+            assembly {
+                r := mload(add(signature, 0x20))
+                s := mload(add(signature, 0x40))
+                v := byte(0, mload(add(signature, 0x60)))
+            }
+            return recover(hash, v, r, s);
+        } else if (signature.length == 64) {
+            bytes32 r;
+            bytes32 vs;
+            // ecrecover takes the signature parameters, and the only way to get them
+            // currently is to use assembly.
+            assembly {
+                r := mload(add(signature, 0x20))
+                vs := mload(add(signature, 0x40))
+            }
+            return recover(hash, r, vs);
+        } else {
+            revert("ECDSA: invalid signature length");
+        }
+    }
+
+    /**
+     * @dev Overload of {ECDSA-recover} that receives the `r` and `vs` short-signature fields separately.
+     *
+     * See https://eips.ethereum.org/EIPS/eip-2098[EIP-2098 short signatures]
+     *
+     * _Available since v4.2._
+     */
+    function recover(
+        bytes32 hash,
+        bytes32 r,
+        bytes32 vs
+    ) internal pure returns (address) {
+        bytes32 s;
+        uint8 v;
+        assembly {
+            s := and(vs, 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+            v := add(shr(255, vs), 27)
+        }
+        return recover(hash, v, r, s);
+    }
+
+    /**
+     * @dev Overload of {ECDSA-recover} that receives the `v`, `r` and `s` signature fields separately.
+     */
+    function recover(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) internal pure returns (address) {
+        // EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature
+        // unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines
+        // the valid range for s in (281): 0 < s < secp256k1n ÷ 2 + 1, and for v in (282): v ∈ {27, 28}. Most
+        // signatures from current libraries generate a unique signature with an s-value in the lower half order.
+        //
+        // If your library generates malleable signatures, such as s-values in the upper range, calculate a new s-value
+        // with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or
+        // vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept
+        // these malleable signatures as well.
+        require(
+            uint256(s) <= 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0,
+            "ECDSA: invalid signature 's' value"
+        );
+        require(v == 27 || v == 28, "ECDSA: invalid signature 'v' value");
+
+        // If the signature is valid (and not malleable), return the signer address
+        address signer = ecrecover(hash, v, r, s);
+        require(signer != address(0), "ECDSA: invalid signature");
+
+        return signer;
+    }
+
+    /**
+     * @dev Returns an Ethereum Signed Message, created from a `hash`. This
+     * produces hash corresponding to the one signed with the
+     * https://eth.wiki/json-rpc/API#eth_sign[`eth_sign`]
+     * JSON-RPC method as part of EIP-191.
+     *
+     * See {recover}.
+     */
+    function toEthSignedMessageHash(bytes32 hash) internal pure returns (bytes32) {
+        // 32 is the length in bytes of hash,
+        // enforced by the type signature above
+        return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash));
+    }
+
+    /**
+     * @dev Returns an Ethereum Signed Typed Data, created from a
+     * `domainSeparator` and a `structHash`. This produces hash corresponding
+     * to the one signed with the
+     * https://eips.ethereum.org/EIPS/eip-712[`eth_signTypedData`]
+     * JSON-RPC method as part of EIP-712.
+     *
+     * See {recover}.
+     */
+    function toTypedDataHash(bytes32 domainSeparator, bytes32 structHash) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+    }
+}
+
+// node_modules/@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20Upgradeable {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * IMPORTANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+// node_modules/@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol
+
+/**
+ * @dev This is a base contract to aid in writing upgradeable contracts, or any kind of contract that will be deployed
+ * behind a proxy. Since a proxied contract can't have a constructor, it's common to move constructor logic to an
+ * external initializer function, usually called `initialize`. It then becomes necessary to protect this initializer
+ * function so it can only be called once. The {initializer} modifier provided by this contract will have this effect.
+ *
+ * TIP: To avoid leaving the proxy in an uninitialized state, the initializer function should be called as early as
+ * possible by providing the encoded function call as the `_data` argument to {ERC1967Proxy-constructor}.
+ *
+ * CAUTION: When used with inheritance, manual care must be taken to not invoke a parent initializer twice, or to ensure
+ * that all initializers are idempotent. This is not verified automatically as constructors are by Solidity.
+ */
+abstract contract Initializable {
+    /**
+     * @dev Indicates that the contract has been initialized.
+     */
+    bool private _initialized;
+
+    /**
+     * @dev Indicates that the contract is in the process of being initialized.
+     */
+    bool private _initializing;
+
+    /**
+     * @dev Modifier to protect an initializer function from being invoked twice.
+     */
+    modifier initializer() {
+        require(_initializing || !_initialized, "Initializable: contract is already initialized");
+
+        bool isTopLevelCall = !_initializing;
+        if (isTopLevelCall) {
+            _initializing = true;
+            _initialized = true;
+        }
+
+        _;
+
+        if (isTopLevelCall) {
+            _initializing = false;
+        }
+    }
+}
+
+// node_modules/@openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-IERC20PermitUpgradeable.sol
+
+/**
+ * @dev Interface of the ERC20 Permit extension allowing approvals to be made via signatures, as defined in
+ * https://eips.ethereum.org/EIPS/eip-2612[EIP-2612].
+ *
+ * Adds the {permit} method, which can be used to change an account's ERC20 allowance (see {IERC20-allowance}) by
+ * presenting a message signed by the account. By not relying on {IERC20-approve}, the token holder account doesn't
+ * need to send a transaction, and thus is not required to hold Ether at all.
+ */
+interface IERC20PermitUpgradeable {
+    /**
+     * @dev Sets `value` as the allowance of `spender` over ``owner``'s tokens,
+     * given ``owner``'s signed approval.
+     *
+     * IMPORTANT: The same issues {IERC20-approve} has related to transaction
+     * ordering also apply here.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `deadline` must be a timestamp in the future.
+     * - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner`
+     * over the EIP712-formatted function arguments.
+     * - the signature must use ``owner``'s current nonce (see {nonces}).
+     *
+     * For more information on the signature format, see the
+     * https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP
+     * section].
+     */
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+
+    /**
+     * @dev Returns the current nonce for `owner`. This value must be
+     * included whenever a signature is generated for {permit}.
+     *
+     * Every successful call to {permit} increases ``owner``'s nonce by one. This
+     * prevents a signature from being used multiple times.
+     */
+    function nonces(address owner) external view returns (uint256);
+
+    /**
+     * @dev Returns the domain separator used in the encoding of the signature for {permit}, as defined by {EIP712}.
+     */
+    // solhint-disable-next-line func-name-mixedcase
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+}
+
+// node_modules/@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol
+
+/*
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract ContextUpgradeable is Initializable {
+    function __Context_init() internal initializer {
+        __Context_init_unchained();
+    }
+
+    function __Context_init_unchained() internal initializer {
+    }
+    function _msgSender() internal view virtual returns (address) {
+        return msg.sender;
+    }
+
+    function _msgData() internal view virtual returns (bytes calldata) {
+        return msg.data;
+    }
+    uint256[50] private __gap;
+}
+
+// node_modules/@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol
+
+/**
+ * @dev Interface for the optional metadata functions from the ERC20 standard.
+ *
+ * _Available since v4.1._
+ */
+interface IERC20MetadataUpgradeable is IERC20Upgradeable {
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() external view returns (string memory);
+
+    /**
+     * @dev Returns the symbol of the token.
+     */
+    function symbol() external view returns (string memory);
+
+    /**
+     * @dev Returns the decimals places of the token.
+     */
+    function decimals() external view returns (uint8);
+}
+
+// node_modules/@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+abstract contract OwnableUpgradeable is Initializable, ContextUpgradeable {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    function __Ownable_init() internal initializer {
+        __Context_init_unchained();
+        __Ownable_init_unchained();
+    }
+
+    function __Ownable_init_unchained() internal initializer {
+        _setOwner(_msgSender());
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view virtual returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(owner() == _msgSender(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        _setOwner(address(0));
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        _setOwner(newOwner);
+    }
+
+    function _setOwner(address newOwner) private {
+        address oldOwner = _owner;
+        _owner = newOwner;
+        emit OwnershipTransferred(oldOwner, newOwner);
+    }
+    uint256[49] private __gap;
+}
+
+// node_modules/@openzeppelin/contracts-upgradeable/utils/cryptography/draft-EIP712Upgradeable.sol
+
+/**
+ * @dev https://eips.ethereum.org/EIPS/eip-712[EIP 712] is a standard for hashing and signing of typed structured data.
+ *
+ * The encoding specified in the EIP is very generic, and such a generic implementation in Solidity is not feasible,
+ * thus this contract does not implement the encoding itself. Protocols need to implement the type-specific encoding
+ * they need in their contracts using a combination of `abi.encode` and `keccak256`.
+ *
+ * This contract implements the EIP 712 domain separator ({_domainSeparatorV4}) that is used as part of the encoding
+ * scheme, and the final step of the encoding to obtain the message digest that is then signed via ECDSA
+ * ({_hashTypedDataV4}).
+ *
+ * The implementation of the domain separator was designed to be as efficient as possible while still properly updating
+ * the chain id to protect against replay attacks on an eventual fork of the chain.
+ *
+ * NOTE: This contract implements the version of the encoding known as "v4", as implemented by the JSON RPC method
+ * https://docs.metamask.io/guide/signing-data.html[`eth_signTypedDataV4` in MetaMask].
+ *
+ * _Available since v3.4._
+ */
+abstract contract EIP712Upgradeable is Initializable {
+    /* solhint-disable var-name-mixedcase */
+    bytes32 private _HASHED_NAME;
+    bytes32 private _HASHED_VERSION;
+    bytes32 private constant _TYPE_HASH = keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+
+    /* solhint-enable var-name-mixedcase */
+
+    /**
+     * @dev Initializes the domain separator and parameter caches.
+     *
+     * The meaning of `name` and `version` is specified in
+     * https://eips.ethereum.org/EIPS/eip-712#definition-of-domainseparator[EIP 712]:
+     *
+     * - `name`: the user readable name of the signing domain, i.e. the name of the DApp or the protocol.
+     * - `version`: the current major version of the signing domain.
+     *
+     * NOTE: These parameters cannot be changed except through a xref:learn::upgrading-smart-contracts.adoc[smart
+     * contract upgrade].
+     */
+    function __EIP712_init(string memory name, string memory version) internal initializer {
+        __EIP712_init_unchained(name, version);
+    }
+
+    function __EIP712_init_unchained(string memory name, string memory version) internal initializer {
+        bytes32 hashedName = keccak256(bytes(name));
+        bytes32 hashedVersion = keccak256(bytes(version));
+        _HASHED_NAME = hashedName;
+        _HASHED_VERSION = hashedVersion;
+    }
+
+    /**
+     * @dev Returns the domain separator for the current chain.
+     */
+    function _domainSeparatorV4() internal view returns (bytes32) {
+        return _buildDomainSeparator(_TYPE_HASH, _EIP712NameHash(), _EIP712VersionHash());
+    }
+
+    function _buildDomainSeparator(
+        bytes32 typeHash,
+        bytes32 nameHash,
+        bytes32 versionHash
+    ) private view returns (bytes32) {
+        return keccak256(abi.encode(typeHash, nameHash, versionHash, block.chainid, address(this)));
+    }
+
+    /**
+     * @dev Given an already https://eips.ethereum.org/EIPS/eip-712#definition-of-hashstruct[hashed struct], this
+     * function returns the hash of the fully encoded EIP712 message for this domain.
+     *
+     * This hash can be used together with {ECDSA-recover} to obtain the signer of a message. For example:
+     *
+     * ```solidity
+     * bytes32 digest = _hashTypedDataV4(keccak256(abi.encode(
+     *     keccak256("Mail(address to,string contents)"),
+     *     mailTo,
+     *     keccak256(bytes(mailContents))
+     * )));
+     * address signer = ECDSA.recover(digest, signature);
+     * ```
+     */
+    function _hashTypedDataV4(bytes32 structHash) internal view virtual returns (bytes32) {
+        return ECDSAUpgradeable.toTypedDataHash(_domainSeparatorV4(), structHash);
+    }
+
+    /**
+     * @dev The hash of the name parameter for the EIP712 domain.
+     *
+     * NOTE: This function reads from storage by default, but can be redefined to return a constant value if gas costs
+     * are a concern.
+     */
+    function _EIP712NameHash() internal virtual view returns (bytes32) {
+        return _HASHED_NAME;
+    }
+
+    /**
+     * @dev The hash of the version parameter for the EIP712 domain.
+     *
+     * NOTE: This function reads from storage by default, but can be redefined to return a constant value if gas costs
+     * are a concern.
+     */
+    function _EIP712VersionHash() internal virtual view returns (bytes32) {
+        return _HASHED_VERSION;
+    }
+    uint256[50] private __gap;
+}
+
+// src/contracts/usdt/WithBlockedList.sol
+
+/*
+
+   Copyright Tether.to 2020
+
+   Author Will Harborne
+
+   Licensed under the Apache License, Version 2.0
+   http://www.apache.org/licenses/LICENSE-2.0
+
+*/
+
+contract WithBlockedList is OwnableUpgradeable {
+    /**
+     * @dev Reverts if called by a blocked account
+     */
+    modifier onlyNotBlocked() {
+        require(!isBlocked[_msgSender()], "Blocked: msg.sender is blocked");
+        _;
+    }
+
+    mapping(address => bool) public isBlocked;
+
+    function addToBlockedList(address _user) public onlyOwner {
+        isBlocked[_user] = true;
+        emit BlockPlaced(_user);
+    }
+
+    function removeFromBlockedList(address _user) public onlyOwner {
+        isBlocked[_user] = false;
+        emit BlockReleased(_user);
+    }
+
+    event BlockPlaced(address indexed _user);
+
+    event BlockReleased(address indexed _user);
+}
+
+// node_modules/@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol
+
+/**
+ * @dev Implementation of the {IERC20} interface.
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+contract ERC20Upgradeable is Initializable, ContextUpgradeable, IERC20Upgradeable, IERC20MetadataUpgradeable {
+    mapping(address => uint256) private _balances;
+
+    mapping(address => mapping(address => uint256)) private _allowances;
+
+    uint256 private _totalSupply;
+
+    string private _name;
+    string private _symbol;
+
+    /**
+     * @dev Sets the values for {name} and {symbol}.
+     *
+     * The default value of {decimals} is 18. To select a different value for
+     * {decimals} you should overload it.
+     *
+     * All two of these values are immutable: they can only be set once during
+     * construction.
+     */
+    function __ERC20_init(string memory name_, string memory symbol_) internal initializer {
+        __Context_init_unchained();
+        __ERC20_init_unchained(name_, symbol_);
+    }
+
+    function __ERC20_init_unchained(string memory name_, string memory symbol_) internal initializer {
+        _name = name_;
+        _symbol = symbol_;
+    }
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public view virtual override returns (string memory) {
+        return _name;
+    }
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public view virtual override returns (string memory) {
+        return _symbol;
+    }
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless this function is
+     * overridden;
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public view virtual override returns (uint8) {
+        return 18;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view virtual override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view virtual override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20}.
+     *
+     * Requirements:
+     *
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+
+        uint256 currentAllowance = _allowances[sender][_msgSender()];
+        require(currentAllowance >= amount, "ERC20: transfer amount exceeds allowance");
+        unchecked {
+            _approve(sender, _msgSender(), currentAllowance - amount);
+        }
+
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender] + addedValue);
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        uint256 currentAllowance = _allowances[_msgSender()][spender];
+        require(currentAllowance >= subtractedValue, "ERC20: decreased allowance below zero");
+        unchecked {
+            _approve(_msgSender(), spender, currentAllowance - subtractedValue);
+        }
+
+        return true;
+    }
+
+    /**
+     * @dev Moves `amount` of tokens from `sender` to `recipient`.
+     *
+     * This internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        uint256 senderBalance = _balances[sender];
+        require(senderBalance >= amount, "ERC20: transfer amount exceeds balance");
+        unchecked {
+            _balances[sender] = senderBalance - amount;
+        }
+        _balances[recipient] += amount;
+
+        emit Transfer(sender, recipient, amount);
+
+        _afterTokenTransfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements:
+     *
+     * - `account` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply += amount;
+        _balances[account] += amount;
+        emit Transfer(address(0), account, amount);
+
+        _afterTokenTransfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements:
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        uint256 accountBalance = _balances[account];
+        require(accountBalance >= amount, "ERC20: burn amount exceeds balance");
+        unchecked {
+            _balances[account] = accountBalance - amount;
+        }
+        _totalSupply -= amount;
+
+        emit Transfer(account, address(0), amount);
+
+        _afterTokenTransfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner` s tokens.
+     *
+     * This internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(
+        address owner,
+        address spender,
+        uint256 amount
+    ) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 amount
+    ) internal virtual {}
+
+    /**
+     * @dev Hook that is called after any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * has been transferred to `to`.
+     * - when `from` is zero, `amount` tokens have been minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens have been burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _afterTokenTransfer(
+        address from,
+        address to,
+        uint256 amount
+    ) internal virtual {}
+    uint256[45] private __gap;
+}
+
+// node_modules/@openzeppelin/contracts-upgradeable/token/ERC20/extensions/draft-ERC20PermitUpgradeable.sol
+
+/**
+ * @dev Implementation of the ERC20 Permit extension allowing approvals to be made via signatures, as defined in
+ * https://eips.ethereum.org/EIPS/eip-2612[EIP-2612].
+ *
+ * Adds the {permit} method, which can be used to change an account's ERC20 allowance (see {IERC20-allowance}) by
+ * presenting a message signed by the account. By not relying on `{IERC20-approve}`, the token holder account doesn't
+ * need to send a transaction, and thus is not required to hold Ether at all.
+ *
+ * _Available since v3.4._
+ */
+abstract contract ERC20PermitUpgradeable is Initializable, ERC20Upgradeable, IERC20PermitUpgradeable, EIP712Upgradeable {
+    using CountersUpgradeable for CountersUpgradeable.Counter;
+
+    mapping(address => CountersUpgradeable.Counter) private _nonces;
+
+    // solhint-disable-next-line var-name-mixedcase
+    bytes32 private _PERMIT_TYPEHASH;
+
+    /**
+     * @dev Initializes the {EIP712} domain separator using the `name` parameter, and setting `version` to `"1"`.
+     *
+     * It's a good idea to use the same `name` that is defined as the ERC20 token name.
+     */
+    function __ERC20Permit_init(string memory name) internal initializer {
+        __Context_init_unchained();
+        __EIP712_init_unchained(name, "1");
+        __ERC20Permit_init_unchained(name);
+    }
+
+    function __ERC20Permit_init_unchained(string memory name) internal initializer {
+        _PERMIT_TYPEHASH = keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");}
+
+    /**
+     * @dev See {IERC20Permit-permit}.
+     */
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public virtual override {
+        require(block.timestamp <= deadline, "ERC20Permit: expired deadline");
+
+        bytes32 structHash = keccak256(abi.encode(_PERMIT_TYPEHASH, owner, spender, value, _useNonce(owner), deadline));
+
+        bytes32 hash = _hashTypedDataV4(structHash);
+
+        address signer = ECDSAUpgradeable.recover(hash, v, r, s);
+        require(signer == owner, "ERC20Permit: invalid signature");
+
+        _approve(owner, spender, value);
+    }
+
+    /**
+     * @dev See {IERC20Permit-nonces}.
+     */
+    function nonces(address owner) public view virtual override returns (uint256) {
+        return _nonces[owner].current();
+    }
+
+    /**
+     * @dev See {IERC20Permit-DOMAIN_SEPARATOR}.
+     */
+    // solhint-disable-next-line func-name-mixedcase
+    function DOMAIN_SEPARATOR() external view override returns (bytes32) {
+        return _domainSeparatorV4();
+    }
+
+    /**
+     * @dev "Consume a nonce": return the current value and increment.
+     *
+     * _Available since v4.1._
+     */
+    function _useNonce(address owner) internal virtual returns (uint256 current) {
+        CountersUpgradeable.Counter storage nonce = _nonces[owner];
+        current = nonce.current();
+        nonce.increment();
+    }
+    uint256[49] private __gap;
+}
+
+// src/contracts/usdt/TetherToken.sol
+
+/*
+
+   Copyright Tether.to 2024
+
+   Version 2.0(a)
+
+   Licensed under the Apache License, Version 2.0
+   http://www.apache.org/licenses/LICENSE-2.0
+
+*/
+
+contract TetherToken is
+    Initializable,
+    ERC20PermitUpgradeable,
+    OwnableUpgradeable,
+    WithBlockedList
+{
+    // Unused variable retained to preserve storage slots across upgrades
+    mapping(address => bool) public isTrusted;
+
+    uint8 private tetherDecimals;
+
+    uint256 constant initialSupply = 1e18;
+
+    function initialize(
+        string memory _name,
+        string memory _symbol,
+        uint8 _decimals
+    ) public initializer {
+        tetherDecimals = _decimals;
+        __Ownable_init();
+        __ERC20_init(_name, _symbol);
+        __ERC20Permit_init(_name);
+
+        _mint(_msgSender(), initialSupply * 10 ** _decimals);
+    }
+
+    function decimals() public view virtual override returns (uint8) {
+        return tetherDecimals;
+    }
+
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256
+    ) internal virtual override {
+        require(
+            !isBlocked[from] || msg.sender == owner(),
+            "TetherToken: from is blocked"
+        );
+        require(
+            to != address(this),
+            "TetherToken: transfer to the contract address"
+        );
+    }
+
+    function transferFrom(
+        address _sender,
+        address _recipient,
+        uint256 _amount
+    ) public virtual override onlyNotBlocked returns (bool) {
+        return super.transferFrom(_sender, _recipient, _amount);
+    }
+
+    function multiTransfer(
+        address[] calldata _recipients,
+        uint256[] calldata _values
+    ) external {
+        require(
+            _recipients.length == _values.length,
+            "TetherToken: multiTransfer mismatch"
+        );
+        for (uint256 i = 0; i < _recipients.length; i++) {
+            transfer(_recipients[i], _values[i]);
+        }
+    }
+
+    function mint(address _destination, uint256 _amount) public onlyOwner {
+        _mint(_destination, _amount);
+        emit Mint(_destination, _amount);
+    }
+
+    function redeem(uint256 _amount) public onlyOwner {
+        _burn(owner(), _amount);
+        emit Redeem(_amount);
+    }
+
+    function destroyBlockedFunds(address _blockedUser) public onlyOwner {
+        require(isBlocked[_blockedUser], "TetherToken: user is not blocked");
+        uint256 blockedFunds = balanceOf(_blockedUser);
+        _burn(_blockedUser, blockedFunds);
+        emit DestroyedBlockedFunds(_blockedUser, blockedFunds);
+    }
+
+    event Mint(address indexed _destination, uint256 _amount);
+    event Redeem(uint256 _amount);
+    event DestroyedBlockedFunds(address indexed _blockedUser, uint256 _balance);
+}

--- a/klayslave/config/config.go
+++ b/klayslave/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	nUserForUnsigned    int
 	nUserForSigned      int
 	nUserForNewAccounts int
+	nUserForTC          int
 	activeUserPercent   int
 
 	richWalletPrivateKey string
@@ -79,6 +80,7 @@ func (cfg *Config) setConfigsFromFlag(ctx *cli.Context) {
 	cfg.nUserForSigned = ctx.Int("vusigned")
 	cfg.nUserForUnsigned = ctx.Int("vuunsigned")
 	cfg.nUserForNewAccounts = 5
+	cfg.nUserForTC = ctx.Int("nUserForTC")
 	cfg.activeUserPercent = ctx.Int("activeUserPercent")
 	cfg.chargeKLAYAmount = ctx.Int("charge")
 	cfg.chargeParallelNum = ctx.Int("chargeParallel")
@@ -148,6 +150,7 @@ func (cfg *Config) setConfigsFromFlag(ctx *cli.Context) {
 	fmt.Printf("- Target EndPoint = %v\n", cfg.gEndpoint)
 	fmt.Printf("- nUserForSigned = %v\n", cfg.nUserForSigned)
 	fmt.Printf("- nUserForUnsigned = %v\n", cfg.nUserForUnsigned)
+	fmt.Printf("- nUserForTC = %v\n", cfg.nUserForTC)
 	fmt.Printf("- activeUserPercent = %v\n", cfg.activeUserPercent)
 	fmt.Printf("- coinbasePrivatekey = %v\n", cfg.richWalletPrivateKey)
 	fmt.Printf("- charging KLAY Amount = %v\n", cfg.chargeKLAYAmount)
@@ -223,6 +226,7 @@ func (cfg *Config) GetBaseFee() *big.Int                 { return cfg.baseFee }
 func (cfg *Config) GetNUserForUnsigned() int             { return cfg.nUserForUnsigned }
 func (cfg *Config) GetNUserForSigned() int               { return cfg.nUserForSigned }
 func (cfg *Config) GetNUserForNewAccounts() int          { return cfg.nUserForNewAccounts }
+func (cfg *Config) GetNUserForTC() int                   { return cfg.nUserForTC }
 func (cfg *Config) GetGEndpoint() string                 { return cfg.gEndpoint }
 func (cfg *Config) GetActiveUserPercent() int            { return cfg.activeUserPercent }
 func (cfg *Config) GetTcStrList() []string               { return cfg.tcNameList }
@@ -248,6 +252,7 @@ var Flags = []cli.Flag{
 	cli.IntFlag{Name: "charge", Value: 1000000000, Usage: "charging amount for each test account in KLAY"},
 	cli.IntFlag{Name: "chargeParallel", Value: 0, Usage: "number of parallel transactions for charging accounts (0 = auto-detect based on CPU cores)"},
 	cli.IntFlag{Name: "maxidleconns", Value: 100, Usage: "maximum number of idle connections in default http client"},
+	cli.IntFlag{Name: "nUserForTC", Value: 0, Usage: "number of additional users for TC-specific purposes (e.g., blocked users in Tether)"},
 	cli.StringFlag{Name: "key", Usage: "private key of rich account for kaia charging of test accounts"},
 	cli.StringFlag{Name: "tc", Value: "", Usage: "tasks which user want to run, multiple tasks are separated by comma."},
 	cli.StringFlag{Name: "weights", Value: "", Usage: "weights which user want to run, multiple weights are separated by comma."},

--- a/klayslave/main.go
+++ b/klayslave/main.go
@@ -71,7 +71,7 @@ func RunAction(ctx *cli.Context) {
 	if account.ContainsAnyInList(tcList, []string{"gaslessOnlyApproveTC"}) {
 		nUserForGaslessApproveTx = cfg.GetNUserForSigned() // same as nUserForSignedTx
 	}
-	accGrp.CreateAccountsPerAccGrp(cfg.GetNUserForSigned(), cfg.GetNUserForUnsigned(), cfg.GetNUserForNewAccounts(), nUserForGaslessRevertTx, nUserForGaslessApproveTx, cfg.GetTcStrList(), cfg.GetGEndpoint())
+	accGrp.CreateAccountsPerAccGrp(cfg.GetNUserForSigned(), cfg.GetNUserForUnsigned(), cfg.GetNUserForNewAccounts(), nUserForGaslessRevertTx, nUserForGaslessApproveTx, cfg.GetNUserForTC(), cfg.GetTcStrList(), cfg.GetGEndpoint())
 
 	createTestAccGroupsAndPrepareContracts(cfg, accGrp)
 

--- a/testcase/run_execute_contract.go
+++ b/testcase/run_execute_contract.go
@@ -83,6 +83,15 @@ func RunErc20TransferTC(config *TCConfig) func() {
 	return RunBaseWithContract(config, txFunc)
 }
 
+func RunErc20TransferWithBlockedListTC(config *TCConfig) func() {
+	txFunc := func(cli *client.Client, from *account.Account, to *account.Account) (interface{}, *big.Int, error) {
+		tetherValue := big.NewInt(int64(rand.Int() % 3))
+		tetherData := account.TestContractInfos[account.ContractTetherProxy].GenData(to.GetAddress(), tetherValue)
+		return from.TransferNewSmartContractExecutionTx(cli, to, nil, tetherData)
+	}
+	return RunBaseWithContract(config, txFunc)
+}
+
 func RunErc721TransferTC(config *TCConfig) func() {
 	return func() {
 		cli := config.CliPool.Alloc().(*client.Client)

--- a/testcase/run_execute_contract.go
+++ b/testcase/run_execute_contract.go
@@ -77,7 +77,8 @@ func RunLargeMemoTC(config *TCConfig) func() {
 func RunErc20TransferTC(config *TCConfig) func() {
 	txFunc := func(cli *client.Client, from *account.Account, to *account.Account) (interface{}, *big.Int, error) {
 		erc20Value := big.NewInt(int64(rand.Int() % 3))
-		erc20Data := account.TestContractInfos[account.ContractErc20].GenData(to.GetAddress(), erc20Value)
+		receiver := config.AccGrp.GetAccountRandomly()
+		erc20Data := account.TestContractInfos[account.ContractErc20].GenData(receiver.GetAddress(), erc20Value)
 		return from.TransferNewSmartContractExecutionTx(cli, to, nil, erc20Data)
 	}
 	return RunBaseWithContract(config, txFunc)
@@ -86,7 +87,8 @@ func RunErc20TransferTC(config *TCConfig) func() {
 func RunErc20TransferWithBlockedListTC(config *TCConfig) func() {
 	txFunc := func(cli *client.Client, from *account.Account, to *account.Account) (interface{}, *big.Int, error) {
 		tetherValue := big.NewInt(int64(rand.Int() % 3))
-		tetherData := account.TestContractInfos[account.ContractTetherProxy].GenData(to.GetAddress(), tetherValue)
+		receiver := config.AccGrp.GetAccountRandomly()
+		tetherData := account.TestContractInfos[account.ContractTetherProxy].GenData(receiver.GetAddress(), tetherValue)
 		return from.TransferNewSmartContractExecutionTx(cli, to, nil, tetherData)
 	}
 	return RunBaseWithContract(config, txFunc)

--- a/testcase/tclist.go
+++ b/testcase/tclist.go
@@ -10,6 +10,7 @@ const (
 	NewValueTransferMemoTCName                           = "newValueTransferMemoTC"
 	NewSmartContractExecutionTCName                      = "newSmartContractExecutionTC"
 	Erc20TransferTCName                                  = "erc20TransferTC"
+	Erc20TransferWithBlockedListTCName                   = "erc20TransferWithBlockedListTC"
 	CpuHeavyTCName                                       = "cpuHeavyTC"
 	NewFeeDelegatedValueTransferTCName                   = "newFeeDelegatedValueTransferTC"
 	NewFeeDelegatedValueTransferWithRatioTCName          = "newFeeDelegatedValueTransferWithRatioTC"
@@ -98,6 +99,13 @@ var TcList = map[string]*ExtendedTask{
 		Init:          Init,
 		Run:           RunErc20TransferTC,
 		TestContracts: []account.TestContract{account.ContractErc20},
+	},
+	Erc20TransferWithBlockedListTCName: {
+		Name:          Erc20TransferWithBlockedListTCName,
+		Weight:        10,
+		Init:          Init,
+		Run:           RunErc20TransferWithBlockedListTC,
+		TestContracts: []account.TestContract{account.ContractTetherProxy, account.ContractTetherLogic},
 	},
 	CpuHeavyTCName: {
 		Name:          CpuHeavyTCName,


### PR DESCRIPTION
## Summary
- Add new test case for ERC20 transfers with blocked list (Tether-like token): `erc20TransferWithBlockedListTC`
- Add TetherProxy and TetherToken contracts with WithBlockedList functionality
- Fix receiver allocation in ERC20 transfer test cases (use random account instead of contract address)
- Add progress percentage logging for concurrent transaction sends